### PR TITLE
fix: Add cancel event emit

### DIFF
--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -95,11 +95,11 @@ export interface Download {
 }
 
 /**
- * Represents a download progress update.
+ * Represents a download event payload.
  */
-export interface DownloadProgress {
+export interface DownloadEvent {
   key: string;
-  progress: number;
+  progress?: number;
 }
 
 /**

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -114,7 +114,7 @@ impl<R: Runtime> Download<R> {
         if fs::remove_file(record.path.clone()).is_err() {
           println!("[{}] File was not found or could not be deleted", &record.key);
         }
-
+        let _ = app.emit("tauri-plugin-download:cancel", DownloadEvent::Cancel{ key: record.key.clone() });
         Ok(record.with_state(DownloadState::Cancelled))
       }
 
@@ -249,7 +249,7 @@ impl<R: Runtime> Download<R> {
                 // Update record or remove if download has completed.
                 DownloadState::InProgress => {
                   println!("[{}] In Progress: {}", &record.key, progress.to_string());
-                  let _ = app.emit("tauri-plugin-download", DownloadProgress { key: record.key.clone(), progress });
+                  let _ = app.emit("tauri-plugin-download:progress", DownloadEvent::Progress { key: record.key.clone(), progress });
                   if progress < 100.0 {                    
                     Download::update_record(app, record.with_progress(progress)).unwrap();
                   }

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,10 +11,15 @@ pub struct DownloadRecord {
 }
 
 #[derive(Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DownloadProgress {
-  pub key: String,
-  pub progress: f64,   
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum DownloadEvent {
+  Progress {
+    key: String,
+    progress: f64,
+  },
+  Cancel {
+    key: String,
+  },
 }
 
 pub trait DownloadRecordExt {


### PR DESCRIPTION
This commit adds an event emit on the cancel endpoint to add verbose confirmation to front end of cancellation.

Also updates the `DownloadProgress` struct to `DownloadEvent` enum to make more generic and inclusive of other events.