### PR TITLE
chore: Allow package to be built and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # tauri-plugin-download
 
-State-driven, resumable download API.
+State-driven, resumable download API for Tauri 2.x apps.
+
+   * Parallel, resumable download support
+   * Persistable, thread-safe store
+   * State and progress notifications
+   * Cross-platform support (Linux, Windows, macOS, Android, iOS)
 
 | Platform | Supported |
 | -------- | --------- |
@@ -10,10 +15,130 @@ State-driven, resumable download API.
 | Android  | ✓         |
 | iOS      | ✓         |
 
-## Contributing
+## Installation
 
-PRs accepted. Please read the Contributing Guide before making a pull request.
+Note: These steps are an interim workaround until the plugin can be published to npm/crates.io.
+
+### Rust
+
+Add the `tauri-plugin-download` crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+tauri-plugin-download = { git = "https://github.com/silvermine/tauri-plugin-download.git" }
+```
+
+### TypeScript
+
+Install the TypeScript bindings via npm:
+
+```bash
+npm install github:@silvermine/tauri-plugin-download
+```
+
+Add `postInstall` step to your `package.json` to build the bindings:
+
+```json
+"postinstall": "cd ./node_modules/@silvermine/tauri-plugin-download && npm install && npm run build"
+```
+
+## Usage
+
+### Rust
+
+Initialize the plugin in your `tauri::Builder`:
+
+```rust
+fn main() {
+   tauri::Builder::default()
+      .plugin(tauri_plugin_download::init())
+      .run(tauri::generate_context!())
+      .expect("error while running tauri application");
+}
+```
+
+### TypeScript
+
+#### Create a download
+
+```ts
+import { create } from "tauri-plugin-download";
+
+async function createDownload() {
+   const key = "file.zip";
+   const url = "https://example.com/file.zip";
+   const path = "/path/to/save/file.zip";
+
+   const download = await create(key, url, path);
+   console.log(`Created '${download.key}':${download.url}`)
+}
+```
+
+#### List downloads
+
+```ts
+import { list } from "tauri-plugin-download";
+
+async function listDownloads() {
+   const downloads = await list();
+   for (let download of downloads) {
+      console.log(`Found '${download.key}':${download.url} [${download.state}, ${download.progress}%]`)
+   }
+}
+```
+
+#### Get a download
+
+```ts
+import { get } from "tauri-plugin-download";
+
+async function getDownload() {
+   const download = await get("file.zip");
+   console.log(`Found '${download.key}':${download.url} [${download.state}, ${download.progress}%]`)
+}
+```
+
+#### Start, pause, resume or cancel a download
+
+```ts
+import { get } from "tauri-plugin-download";
+
+async function getDownloadAndUpdate() {
+   const download = await get("file.zip");
+   download.start();   // Start download
+   download.pause();   // Pause download
+   download.resume();  // Resume download
+   download.cancel();  // Cancel download
+}
+```
+
+#### Listen for progress notifications
+
+```ts
+import { get } from "tauri-plugin-download";
+
+async function getDownloadAndListen() {
+   const download = await get("file.zip");
+   const unlisten = await download.listen((updatedDownload) => {
+      console.log(`'${download.key}':${download.progress}%`)
+   });
+
+   // To stop listening
+   unlisten();
+}
+```
+
+### Examples
+
+Check out the [examples/tauri-app](examples/tauri-app) directory for a working example of how to use this plugin.
+
+## How do I contribute?
+
+We genuinely appreciate external contributions. See [our extensive
+documentation](https://github.com/silvermine/silvermine-info#contributing) on how to
+contribute.
 
 ## License
 
-MIT or MIT/Apache 2.0 where applicable.
+This software is released under the MIT license. See [the license file](LICENSE) for more
+details.

--- a/examples/tauri-app/package.json
+++ b/examples/tauri-app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "vue": "^3.5.13",
     "@tauri-apps/api": "^2",
-    "tauri-plugin-download-api": "file:../../"
+    "tauri-plugin-download": "file:../../"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/examples/tauri-app/src/App.vue
+++ b/examples/tauri-app/src/App.vue
@@ -29,7 +29,7 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
 import { appDataDir, join } from '@tauri-apps/api/path';
-import { create, list, Download } from 'tauri-plugin-download-api';
+import { create, list, Download } from 'tauri-plugin-download';
 import DownloadView from './DownloadView.vue';
 
 const downloadURL = ref(''),

--- a/examples/tauri-app/src/DownloadView.vue
+++ b/examples/tauri-app/src/DownloadView.vue
@@ -18,7 +18,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, PropType, ref } from 'vue';
-import { Download, DownloadState } from 'tauri-plugin-download-api';
+import { Download, DownloadState } from 'tauri-plugin-download';
 import { UnlistenFn } from '@tauri-apps/api/event';
 
 const props = defineProps({

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -101,7 +101,7 @@ export enum DownloadState {
  * Creates a download operation.
  *
  * @param key - The key identifier.
- * @param url - The download URL  for the resource.
+ * @param url - The download URL for the resource.
  * @param path - The download path on the filesystem.
  * @returns - The download operation.
  */

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tauri-plugin-download-api",
+  "name": "tauri-plugin-download",
   "version": "0.1.0",
   "author": "You",
   "description": "",
@@ -14,6 +14,9 @@
   },
   "files": [
     "dist-js",
+    "guest-js",
+    "rollup.config.js",
+    "tsconfig.json",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
Allow the package to be built when installed using `npm install` from GitHub.
Rename JS package to _tauri-plugin-download_.
Update README.md to include setup and usage instructions.