### PR TITLE
feat: add connection info crate

### DIFF
--- a/crates/connection-info/Cargo.toml
+++ b/crates/connection-info/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "connection-info"
+version = "0.1.0"
+description = "Provides connection information and metadata"
+license = "MIT"
+edition = "2024"
+rust-version = "1.89"
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+thiserror = "2.0.18"
+
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.62.2"
+features = [
+	"Networking_Connectivity",
+]
+
+[dev-dependencies]
+serde_json = "1.0.149"

--- a/crates/connection-info/src/error.rs
+++ b/crates/connection-info/src/error.rs
@@ -1,0 +1,30 @@
+use serde::{Serialize, ser::Serializer};
+
+/// Errors that can occur when detecting the connection type.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+   /// The device has no active internet connection.
+   #[error("no active internet connection")]
+   NoConnection,
+
+   /// The current platform does not support connection type detection.
+   #[error("connection type detection is not supported on this platform")]
+   Unsupported,
+
+   /// A Windows API call failed.
+   #[cfg(windows)]
+   #[error("windows API error: {0}")]
+   Windows(#[from] windows::core::Error),
+}
+
+impl Serialize for Error {
+   fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+   where
+      S: Serializer,
+   {
+      serializer.serialize_str(self.to_string().as_ref())
+   }
+}
+
+/// A specialized [`Result`] type for connection info operations.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/connection-info/src/lib.rs
+++ b/crates/connection-info/src/lib.rs
@@ -1,0 +1,86 @@
+mod error;
+mod types;
+
+#[cfg(not(windows))]
+mod unsupported;
+#[cfg(windows)]
+mod windows;
+
+pub use error::{Error, Result};
+pub use types::{ConnectionStatus, ConnectionType};
+
+/// Queries the current connection status.
+///
+/// Returns a [`ConnectionStatus`] describing whether the connection is metered, constrained,
+/// and what physical transport is in use.
+///
+/// # Errors
+///
+/// Returns [`Error::Unsupported`] on platforms without an implementation, or
+/// [`Error::Windows`] if a Windows API call fails.
+pub fn connection_status() -> Result<ConnectionStatus> {
+   #[cfg(windows)]
+   {
+      self::windows::connection_status()
+   }
+   #[cfg(not(windows))]
+   {
+      self::unsupported::connection_status()
+   }
+}
+
+#[cfg(test)]
+mod tests {
+   use super::*;
+
+   // serialization
+
+   #[test]
+   fn serializes_connection_status() {
+      let status = ConnectionStatus {
+         metered: true,
+         constrained: false,
+         connection_type: ConnectionType::Cellular,
+      };
+      let json = serde_json::to_value(&status).unwrap();
+      assert_eq!(json["metered"], true);
+      assert_eq!(json["constrained"], false);
+      assert_eq!(json["connectionType"], "cellular");
+   }
+
+   #[test]
+   fn deserializes_connection_status() {
+      let json = r#"{"metered":false,"constrained":false,"connectionType":"wifi"}"#;
+      let status: ConnectionStatus = serde_json::from_str(json).unwrap();
+      assert!(!status.metered);
+      assert!(!status.constrained);
+      assert_eq!(status.connection_type, ConnectionType::Wifi);
+   }
+
+   // error
+
+   #[test]
+   fn unsupported_error_displays_message() {
+      let err = Error::Unsupported;
+      assert_eq!(
+         err.to_string(),
+         "connection type detection is not supported on this platform"
+      );
+   }
+
+   #[test]
+   fn no_connection_error_displays_message() {
+      let err = Error::NoConnection;
+      assert_eq!(err.to_string(), "no active internet connection");
+   }
+
+   // stub
+
+   #[test]
+   #[cfg(not(windows))]
+   fn non_windows_returns_unsupported_error() {
+      let result = connection_status();
+      assert!(result.is_err());
+      assert!(matches!(result.unwrap_err(), Error::Unsupported));
+   }
+}

--- a/crates/connection-info/src/types.rs
+++ b/crates/connection-info/src/types.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+/// Describes the physical or logical transport used to connect to the network.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ConnectionType {
+   /// Connected via Wi-Fi.
+   Wifi,
+
+   /// Connected via Ethernet (wired).
+   Ethernet,
+
+   /// Connected via a cellular network (WWAN).
+   Cellular,
+
+   /// The connection type could not be determined.
+   Unknown,
+}
+
+/// Information about the current network connection.
+///
+/// Combines cost/constraint flags with the physical [`ConnectionType`] to give callers
+/// enough context to make download policy decisions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionStatus {
+   /// Whether data usage is billed or limited (e.g. mobile data plans, capped hotspots).
+   pub metered: bool,
+
+   /// Whether the connection is constrained — approaching or over its data limit,
+   /// or background data usage is restricted.
+   pub constrained: bool,
+
+   /// The physical or logical transport used to connect to the network.
+   pub connection_type: ConnectionType,
+}

--- a/crates/connection-info/src/unsupported.rs
+++ b/crates/connection-info/src/unsupported.rs
@@ -1,0 +1,6 @@
+use crate::{ConnectionStatus, Error, Result};
+
+/// On unsupported platforms, returns an [`Error::Unsupported`] error.
+pub(crate) fn connection_status() -> Result<ConnectionStatus> {
+   Err(Error::Unsupported)
+}

--- a/crates/connection-info/src/windows.rs
+++ b/crates/connection-info/src/windows.rs
@@ -1,0 +1,60 @@
+use windows::Networking::Connectivity::NetworkInformation;
+
+use crate::{ConnectionStatus, ConnectionType, Result};
+
+/// [`NetworkCostType`](https://learn.microsoft.com/en-us/uwp/api/windows.networking.connectivity.networkcosttype) ordinals.
+const NETWORK_COST_FIXED: i32 = 2;
+const NETWORK_COST_VARIABLE: i32 = 3;
+
+/// [`IanaInterfaceType`](https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib) values.
+const IANA_ETHERNET: u32 = 6;
+const IANA_WIFI: u32 = 71;
+const IANA_WWAN_PP: u32 = 243;
+const IANA_WWAN_PP2: u32 = 244;
+
+/// Queries the current connection status on Windows.
+///
+/// Uses [`ConnectionCost`](https://learn.microsoft.com/en-us/uwp/api/windows.networking.connectivity.connectioncost)
+/// for metered/constrained flags, and
+/// [`IsWwanConnectionProfile`](https://learn.microsoft.com/en-us/uwp/api/windows.networking.connectivity.connectionprofile.iswwanconnectionprofile) /
+/// [`IsWlanConnectionProfile`](https://learn.microsoft.com/en-us/uwp/api/windows.networking.connectivity.connectionprofile.iswlanconnectionprofile)
+/// to determine the physical connection type.
+pub(crate) fn connection_status() -> Result<ConnectionStatus> {
+   let profile =
+      NetworkInformation::GetInternetConnectionProfile().map_err(|_| crate::Error::NoConnection)?;
+   let cost = profile.GetConnectionCost()?;
+
+   let metered = matches!(
+      cost.NetworkCostType()?.0,
+      NETWORK_COST_FIXED | NETWORK_COST_VARIABLE
+   );
+   let constrained = cost.ApproachingDataLimit()? || cost.OverDataLimit()? || cost.Roaming()?;
+
+   let connection_type = if profile.IsWwanConnectionProfile()? {
+      ConnectionType::Cellular
+   } else if profile.IsWlanConnectionProfile()? {
+      ConnectionType::Wifi
+   } else {
+      iana_interface_type(&profile).unwrap_or(ConnectionType::Unknown)
+   };
+
+   Ok(ConnectionStatus {
+      metered,
+      constrained,
+      connection_type,
+   })
+}
+
+/// Maps the adapter's IANA interface type to a [`ConnectionType`].
+fn iana_interface_type(
+   profile: &windows::Networking::Connectivity::ConnectionProfile,
+) -> Option<ConnectionType> {
+   let iana_type = profile.NetworkAdapter().ok()?.IanaInterfaceType().ok()?;
+
+   Some(match iana_type {
+      IANA_ETHERNET => ConnectionType::Ethernet,
+      IANA_WIFI => ConnectionType::Wifi,
+      IANA_WWAN_PP | IANA_WWAN_PP2 => ConnectionType::Cellular,
+      _ => ConnectionType::Unknown,
+   })
+}


### PR DESCRIPTION
Adds a new `connection-info` crate that detects network connection type and metered/constrained status.
- On Windows, it queries the WinRT NetworkInformation API
- On non-Windows platforms, it returns an `Unsupported` error

```rust
use connection_info::{connection_status, ConnectionType};
 
fn main() {
    match connection_status() {
        Ok(status) => {
            println!("Metered: {}", status.metered);
            println!("Constrained: {}", status.constrained);
            println!("Connection type: {:?}", status.connection_type);
 
            if status.metered || status.connection_type == ConnectionType::Cellular {
                println!("Mobile-like connection detected");
            }
        }
        Err(e) => eprintln!("Could not detect connection status: {e}"),
    }
}
```