### PR TITLE
chore: align naming with Silvermine standards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsScreen.kt
+++ b/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsScreen.kt
@@ -63,8 +63,8 @@ fun DownloadsScreen(viewModel: DownloadsViewModel = viewModel()) {
             modifier = Modifier.fillMaxWidth(),
          ) {
             OutlinedTextField(
-               value = state.downloadUrl,
-               onValueChange = viewModel::updateUrl,
+               value = state.downloadURL,
+               onValueChange = viewModel::updateURL,
                placeholder = { Text("https://example.com/file.zip") },
                singleLine = true,
                modifier = Modifier.weight(1f),
@@ -72,7 +72,7 @@ fun DownloadsScreen(viewModel: DownloadsViewModel = viewModel()) {
 
             Button(
                onClick = viewModel::getDownload,
-               enabled = state.downloadUrl.isNotBlank(),
+               enabled = state.downloadURL.isNotBlank(),
             ) {
                Text("Get")
             }

--- a/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsViewModel.kt
+++ b/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsViewModel.kt
@@ -20,7 +20,7 @@ data class PendingDownload(
 data class DownloadsUiState(
    val downloads: List<DownloadItem> = emptyList(),
    val pendingDownloads: List<PendingDownload> = emptyList(),
-   val downloadUrl: String = "",
+   val downloadURL: String = "",
    val autoCreate: Boolean = true,
 )
 
@@ -41,8 +41,8 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
       }
    }
 
-   fun updateUrl(url: String) {
-      _uiState.value = _uiState.value.copy(downloadUrl = url)
+   fun updateURL(url: String) {
+      _uiState.value = _uiState.value.copy(downloadURL = url)
    }
 
    fun updateAutoCreate(autoCreate: Boolean) {
@@ -51,7 +51,7 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
 
    fun getDownload() {
       val state = _uiState.value
-      val url = state.downloadUrl.trim()
+      val url = state.downloadURL.trim()
       if (url.isEmpty()) return
 
       try {
@@ -71,17 +71,17 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
          if (state.autoCreate) {
             manager.create(path, url)
             _uiState.value = _uiState.value.copy(
-               downloadUrl = "",
+               downloadURL = "",
                downloads = manager.list(),
             )
          } else {
             _uiState.value = _uiState.value.copy(
-               downloadUrl = "",
+               downloadURL = "",
                pendingDownloads = state.pendingDownloads + PendingDownload(url = url, path = path),
             )
          }
       } else {
-         _uiState.value = _uiState.value.copy(downloadUrl = "")
+         _uiState.value = _uiState.value.copy(downloadURL = "")
       }
    }
 

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
@@ -205,7 +205,7 @@ class DownloadManager private constructor(context: Context) {
          item.status != DownloadStatus.InProgress &&
          item.status != DownloadStatus.Paused
       ) {
-         return DownloadActionResponse.withExpectedStatus(item, DownloadStatus.Cancelled)
+         return DownloadActionResponse.withExpectedStatus(item, DownloadStatus.Canceled)
       }
 
       // Cancel the WorkManager work if running.
@@ -216,11 +216,11 @@ class DownloadManager private constructor(context: Context) {
       if (tempFile.exists()) tempFile.delete()
 
       // Remove from store and emit change.
-      val cancelled = item.withStatus(DownloadStatus.Cancelled)
+      val canceled = item.withStatus(DownloadStatus.Canceled)
       store.remove(item)
-      emitChanged(cancelled)
+      emitChanged(canceled)
 
-      return DownloadActionResponse.new(cancelled)
+      return DownloadActionResponse.new(canceled)
    }
 
    /**

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadStatus.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadStatus.kt
@@ -28,9 +28,9 @@ enum class DownloadStatus {
    @SerialName("paused")
    Paused,
 
-   /** Download was cancelled by the user. */
-   @SerialName("cancelled")
-   Cancelled,
+   /** Download was canceled by the user. */
+   @SerialName("canceled")
+   Canceled,
 
    /** Download completed. */
    @SerialName("completed")

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
@@ -263,7 +263,7 @@ internal class DownloadWorker(
       return Result.failure()
    }
 
-   private fun notificationId(): Int = id.hashCode()
+   private fun notificationID(): Int = id.hashCode()
 
    private fun ensureNotificationChannel() {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -291,21 +291,21 @@ internal class DownloadWorker(
       ensureNotificationChannel()
       val notification = buildNotification(File(path).name, 0, indeterminate = true)
       return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-         ForegroundInfo(notificationId(), notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+         ForegroundInfo(notificationID(), notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
       } else {
-         ForegroundInfo(notificationId(), notification)
+         ForegroundInfo(notificationID(), notification)
       }
    }
 
    private fun updateNotificationProgress(path: String, progress: Int) {
       val notification = buildNotification(File(path).name, progress, indeterminate = false)
       val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-      notificationManager.notify(notificationId(), notification)
+      notificationManager.notify(notificationID(), notification)
    }
 
    private fun dismissNotification() {
       val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-      notificationManager.cancel(notificationId())
+      notificationManager.cancel(notificationID())
    }
 
    /**

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
@@ -110,7 +110,7 @@ internal class DownloadWorker(
                val source = body.byteStream()
 
                while (true) {
-                  // Check if the worker has been stopped (cancelled externally).
+                  // Check if the worker has been stopped (canceled externally).
                   if (isStopped) {
                      source.close()
                      dismissNotification()
@@ -231,9 +231,9 @@ internal class DownloadWorker(
       synchronized(manager) {
          if (tempFile.exists()) tempFile.delete()
          store.findByPath(path)?.let { item ->
-            val cancelled = item.withStatus(DownloadStatus.Cancelled)
+            val canceled = item.withStatus(DownloadStatus.Canceled)
             store.remove(item)
-            manager.emitChanged(cancelled)
+            manager.emitChanged(canceled)
          }
       }
 

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/URIParser.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/URIParser.kt
@@ -32,8 +32,8 @@ fun parsePath(pathString: String): String {
    // Resolve path traversal sequences (e.g., /../) to a canonical form.
    val canonicalPath = File(path).canonicalPath
 
-   val fileName = canonicalPath.substringAfterLast("/")
-   if (fileName.isEmpty()) {
+   val filename = canonicalPath.substringAfterLast("/")
+   if (filename.isEmpty()) {
       throw IllegalArgumentException("Path must have a filename")
    }
 
@@ -44,7 +44,7 @@ fun parsePath(pathString: String): String {
  * Parses and validates a download URL string.
  * Checks that the URL is valid, has a valid scheme (http or https) and has a valid host.
  */
-fun parseUrl(urlString: String): String {
+fun parseURI(urlString: String): String {
    val uri = try {
       URI(urlString)
    } catch (e: Exception) {

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/URIParserTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/URIParserTest.kt
@@ -4,7 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
-class UrlParserTest {
+class URIParserTest {
 
    // -- parsePath tests --
 
@@ -50,57 +50,57 @@ class UrlParserTest {
       }
    }
 
-   // -- parseUrl tests --
+   // -- parseURI tests --
 
    @Test
    fun `valid URLs`() {
-      assertEquals("https://example.com/file.mp4", parseUrl("https://example.com/file.mp4"))
-      assertEquals("http://example.com/file.mp4", parseUrl("http://example.com/file.mp4"))
-      assertEquals("https://example.com:8080/file.mp4", parseUrl("https://example.com:8080/file.mp4"))
-      assertEquals("https://example.com/file.mp4?token=abc", parseUrl("https://example.com/file.mp4?token=abc"))
+      assertEquals("https://example.com/file.mp4", parseURI("https://example.com/file.mp4"))
+      assertEquals("http://example.com/file.mp4", parseURI("http://example.com/file.mp4"))
+      assertEquals("https://example.com:8080/file.mp4", parseURI("https://example.com:8080/file.mp4"))
+      assertEquals("https://example.com/file.mp4?token=abc", parseURI("https://example.com/file.mp4?token=abc"))
    }
 
    @Test
    fun `empty URL throws`() {
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("")
+         parseURI("")
       }
    }
 
    @Test
    fun `invalid scheme throws`() {
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("ftp://example.com/file.mp4")
+         parseURI("ftp://example.com/file.mp4")
       }
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("file:///path/to/file.mp4")
+         parseURI("file:///path/to/file.mp4")
       }
    }
 
    @Test
    fun `missing host throws`() {
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("https://:8080/file.mp4")
+         parseURI("https://:8080/file.mp4")
       }
    }
 
    @Test
    fun `URL with credentials throws`() {
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("https://user:pass@example.com/file.mp4")
+         parseURI("https://user:pass@example.com/file.mp4")
       }
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("https://user@example.com/file.mp4")
+         parseURI("https://user@example.com/file.mp4")
       }
    }
 
    @Test
    fun `invalid URL format throws`() {
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("not a valid url")
+         parseURI("not a valid url")
       }
       assertThrows(IllegalArgumentException::class.java) {
-         parseUrl("/not a valid url")
+         parseURI("/not a valid url")
       }
    }
 }

--- a/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
+++ b/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
@@ -11,7 +11,7 @@ import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
 import org.silvermine.downloadmanager.DownloadManager
 import org.silvermine.downloadmanager.parsePath
-import org.silvermine.downloadmanager.parseUrl
+import org.silvermine.downloadmanager.parseURI
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -99,7 +99,7 @@ class DownloadPlugin(activity: Activity) : Plugin(activity) {
          return invoke.reject(e.message)
       }
       val url = try {
-         parseUrl(args.url ?: throw IllegalArgumentException("Missing required argument: url"))
+         parseURI(args.url ?: throw IllegalArgumentException("Missing required argument: url"))
       } catch (e: Exception) {
          return invoke.reject(e.message)
       }

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -199,7 +199,7 @@ impl DownloadManager {
          if let Err(e) = downloader::download(&manager, item_in_progress).await {
             error!(file = %filename(&path), "Download {}: {}", err_msg, e);
 
-            // Revert unless already paused or cancelled.
+            // Revert unless already paused or canceled.
             if let Ok(Some(current)) = manager.store.find_by_path(&path)
                && current.status == DownloadStatus::InProgress
             {
@@ -264,7 +264,7 @@ impl DownloadManager {
          .find_by_path(path)?
          .ok_or_else(|| Error::NotFound(path.to_string()))?;
       match item.status {
-         // Allow download to be cancelled when created, in progress or paused.
+         // Allow download to be canceled when created, in progress or paused.
          DownloadStatus::Idle | DownloadStatus::InProgress | DownloadStatus::Paused => {
             self.store.delete(&item.path)?;
             let temp_path = format!("{}{}", item.path, DOWNLOAD_SUFFIX);
@@ -272,16 +272,16 @@ impl DownloadManager {
                debug!(file = %filename(&item.path), "Temp file was not found or could not be deleted");
             }
 
-            self.emit_changed(item.with_status(DownloadStatus::Cancelled));
+            self.emit_changed(item.with_status(DownloadStatus::Canceled));
             Ok(DownloadActionResponse::new(
-               item.with_status(DownloadStatus::Cancelled),
+               item.with_status(DownloadStatus::Canceled),
             ))
          }
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
             item,
-            DownloadStatus::Cancelled,
+            DownloadStatus::Canceled,
          )),
       }
    }

--- a/crates/download-manager/src/models.rs
+++ b/crates/download-manager/src/models.rs
@@ -24,8 +24,8 @@ pub enum DownloadStatus {
    InProgress,
    /// Download was in progress but has been paused.
    Paused,
-   /// Download was cancelled by the user.
-   Cancelled,
+   /// Download was canceled by the user.
+   Canceled,
    /// Download completed.
    Completed,
 }
@@ -88,7 +88,7 @@ impl fmt::Display for DownloadStatus {
          DownloadStatus::Idle => "Idle",
          DownloadStatus::InProgress => "InProgress",
          DownloadStatus::Paused => "Paused",
-         DownloadStatus::Cancelled => "Cancelled",
+         DownloadStatus::Canceled => "Canceled",
          DownloadStatus::Completed => "Completed",
       };
       write!(f, "{}", text)

--- a/examples/tauri-app/src/DownloadView.vue
+++ b/examples/tauri-app/src/DownloadView.vue
@@ -73,13 +73,13 @@ type ActionHandlers = Partial<{
 
 const unexpectedStatusHandlers: ActionHandlers = {
    [DownloadAction.Start]: {
-      [DownloadStatus.Cancelled]: () => {
-         // Tried to start the download but it was cancelled instead
+      [DownloadStatus.Canceled]: () => {
+         // Tried to start the download but it was canceled instead
       },
    },
    [DownloadAction.Resume]: {
-      [DownloadStatus.Cancelled]: () => {
-         // Tried to start the download but it was cancelled instead
+      [DownloadStatus.Canceled]: () => {
+         // Tried to start the download but it was canceled instead
       },
    },
 
@@ -89,7 +89,7 @@ const unexpectedStatusHandlers: ActionHandlers = {
          // the download but wasn't able to before it completed
       },
       [DownloadStatus.InProgress]: (): void => {
-         // There was a problem cancelling the download
+         // There was a problem canceling the download
       },
    },
 

--- a/guest-js/index.test.ts
+++ b/guest-js/index.test.ts
@@ -92,8 +92,8 @@ beforeEach(() => {
       if (cmd === 'plugin:download|cancel') {
          return {
             ...ACTION_RESPONSE_BASE,
-            expectedStatus: DownloadStatus.Cancelled,
-            download: { ...IDLE_STATE, status: DownloadStatus.Cancelled },
+            expectedStatus: DownloadStatus.Canceled,
+            download: { ...IDLE_STATE, status: DownloadStatus.Canceled },
          };
       }
       if (cmd === 'plugin:download|is_native') {
@@ -191,7 +191,7 @@ describe('download actions', () => {
       expect(response.download.status).toBe(DownloadStatus.InProgress);
    });
 
-   it('cancel — sends path, returns Cancelled download', async () => {
+   it('cancel — sends path, returns Canceled download', async () => {
       const download = await get('/tmp/file.zip');
 
       if (!hasAction(download, DownloadAction.Cancel)) {
@@ -202,7 +202,7 @@ describe('download actions', () => {
       expect(lastCmd).toBe('plugin:download|cancel');
       expect(lastArgs.path).toBe('/tmp/file.zip');
       expect(response.isExpectedStatus).toBe(true);
-      expect(response.download.status).toBe(DownloadStatus.Cancelled);
+      expect(response.download.status).toBe(DownloadStatus.Canceled);
    });
 
    it('handles errors thrown by the backend', async () => {
@@ -277,10 +277,10 @@ describe('state machine — action availability', () => {
       expect(hasAction(download, DownloadAction.Cancel)).toBe(false);
    });
 
-   it('Cancelled: no actions available', () => {
+   it('Canceled: no actions available', () => {
       const download = attachDownload({
          ...IDLE_STATE,
-         status: DownloadStatus.Cancelled,
+         status: DownloadStatus.Canceled,
       });
 
       expect(hasAnyAction(download)).toBe(false);

--- a/guest-js/types.ts
+++ b/guest-js/types.ts
@@ -32,8 +32,8 @@ export enum DownloadStatus {
    /** Download was in progress but has been paused. */
    Paused = 'paused',
 
-   /** Download was cancelled by the user. */
-   Cancelled = 'cancelled',
+   /** Download was canceled by the user. */
+   Canceled = 'canceled',
 
    /** Download completed. */
    Completed = 'completed',
@@ -113,7 +113,7 @@ export const allowedActions = {
       DownloadAction.Cancel,
    ],
    [DownloadStatus.Completed]: [],
-   [DownloadStatus.Cancelled]: [],
+   [DownloadStatus.Canceled]: [],
    [DownloadStatus.Unknown]: [
       DownloadAction.Listen,
    ],
@@ -124,7 +124,7 @@ export const expectedStatusesForAction = {
    [DownloadAction.Start]: [ DownloadStatus.InProgress ],
    [DownloadAction.Resume]: [ DownloadStatus.InProgress ],
    [DownloadAction.Pause]: [ DownloadStatus.Paused ],
-   [DownloadAction.Cancel]: [ DownloadStatus.Cancelled ],
+   [DownloadAction.Cancel]: [ DownloadStatus.Canceled ],
 
    // Everything but "unknown" is valid:
    [DownloadAction.Listen]: [
@@ -132,7 +132,7 @@ export const expectedStatusesForAction = {
       DownloadStatus.Idle,
       DownloadStatus.InProgress,
       DownloadStatus.Paused,
-      DownloadStatus.Cancelled,
+      DownloadStatus.Canceled,
       DownloadStatus.Completed,
    ],
 } as const satisfies Record<DownloadAction, DownloadStatus[] | []>;
@@ -175,6 +175,6 @@ export function hasAction<A extends DownloadAction>(download: DownloadWithAnySta
 /**
  * @returns `true` if the download has actions available, i.e. not in a terminal state.
  */
-export function hasAnyAction(download: DownloadWithAnyStatus): download is Exclude<DownloadWithAnyStatus, Download<DownloadStatus.Completed> | Download<DownloadStatus.Cancelled>> {
-   return download.status !== DownloadStatus.Completed && download.status !== DownloadStatus.Cancelled;
+export function hasAnyAction(download: DownloadWithAnyStatus): download is Exclude<DownloadWithAnyStatus, Download<DownloadStatus.Completed> | Download<DownloadStatus.Canceled>> {
+   return download.status !== DownloadStatus.Completed && download.status !== DownloadStatus.Canceled;
 }

--- a/ios/DownloadManagerExample/DownloadManagerExample/DownloadsView.swift
+++ b/ios/DownloadManagerExample/DownloadManagerExample/DownloadsView.swift
@@ -15,7 +15,7 @@ struct PendingDownload: Identifiable {
 struct DownloadsView: View {
    private let manager = DownloadManager.shared
    @State private var downloads: [DownloadItem] = []
-   @State private var downloadUrl: String = ""
+   @State private var downloadURL: String = ""
    @State private var autoCreate: Bool = true
    @State private var pendingDownloads: [PendingDownload] = []
 
@@ -28,7 +28,7 @@ struct DownloadsView: View {
                .padding(.top)
             
             HStack {
-               TextField("https://example.com/file.zip", text: $downloadUrl)
+               TextField("https://example.com/file.zip", text: $downloadURL)
                   .textFieldStyle(RoundedBorderTextFieldStyle())
                   .autocapitalization(.none)
                   .disableAutocorrection(true)
@@ -42,7 +42,7 @@ struct DownloadsView: View {
                      .foregroundColor(.white)
                      .cornerRadius(8)
                }
-               .disabled(downloadUrl.isEmpty)
+               .disabled(downloadURL.isEmpty)
             }
             .padding(.horizontal)
             
@@ -72,8 +72,8 @@ struct DownloadsView: View {
    }
 
    private func getDownload() {
-      guard !downloadUrl.isEmpty,
-            let url = URL(string: downloadUrl),
+      guard !downloadURL.isEmpty,
+            let url = URL(string: downloadURL),
             url.scheme != nil && url.host != nil else {
          return
       }
@@ -93,7 +93,7 @@ struct DownloadsView: View {
          }
       }
       
-      downloadUrl = ""
+      downloadURL = ""
    }
 }
 

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadError.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadError.swift
@@ -7,5 +7,5 @@
 public enum DownloadError: Error {
    case notFound(String)
    case invalidPath(String)
-   case invalidUrl(String)
+   case invalidURL(String)
 }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
@@ -171,7 +171,7 @@ public final class DownloadManager: NSObject {
       }
       
       // Cancel task and collect resume data via callback. The callback and
-      // handleError may both try to persist resume data; mutateItem serialises
+      // handleError may both try to persist resume data; mutateItem serializes
       // access through the actor so only one wins, and the duplicate is cleaned up.
       task.cancel(byProducingResumeData: { [weak self] data in
          guard let self, let data else { return }
@@ -207,7 +207,7 @@ public final class DownloadManager: NSObject {
       }
 
       guard item.status == .idle || item.status == .inProgress || item.status == .paused else {
-         return DownloadActionResponse(download: item, expectedStatus: .cancelled)
+         return DownloadActionResponse(download: item, expectedStatus: .canceled)
       }
       
       if let task = await getDownloadTask(path.path) {
@@ -219,7 +219,7 @@ public final class DownloadManager: NSObject {
          item.setResumeDataPath(nil)
       }
       
-      item.setStatus(.cancelled)
+      item.setStatus(.canceled)
       await store.remove(item)
       await emitChanged(item)
       
@@ -316,7 +316,7 @@ public final class DownloadManager: NSObject {
       
       // Download failed - update status and clean up
       deleteResumeData(for: item)
-      if let updated = await mutateItem(path: item.path, { $0.setStatus(.cancelled) }) {
+      if let updated = await mutateItem(path: item.path, { $0.setStatus(.canceled) }) {
          await store.remove(updated)
          await emitChanged(updated)
       }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStatus.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStatus.swift
@@ -15,8 +15,8 @@ public enum DownloadStatus: String, Codable, Sendable {
    case inProgress
    /// Download was in progress but has been paused.
    case paused
-   /// Download was cancelled by the user.
-   case cancelled
+   /// Download was canceled by the user.
+   case canceled
    /// Download completed.
    case completed
 }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/URLParser.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/URLParser.swift
@@ -1,5 +1,5 @@
 //
-//  UrlParser.swift
+//  URLParser.swift
 //  DownloadManagerKit
 //
 
@@ -14,18 +14,18 @@ public func parsePath(_ pathString: String) throws -> URL {
 
    let url: URL
    if pathString.hasPrefix("file://") {
-       guard let fileUrl = URL(string: pathString), fileUrl.isFileURL else {
+       guard let fileURL = URL(string: pathString), fileURL.isFileURL else {
            throw DownloadError.invalidPath("Invalid file URL: \(pathString)")
        }
-       url = fileUrl
+       url = fileURL
    } else if pathString.hasPrefix("/") {
        url = URL(fileURLWithPath: pathString)
    } else {
        throw DownloadError.invalidPath("Path must be absolute")
    }
 
-   let fileName = url.lastPathComponent
-   if fileName.isEmpty || fileName == "/" {
+   let filename = url.lastPathComponent
+   if filename.isEmpty || filename == "/" {
        throw DownloadError.invalidPath("Path must have a filename")
    }
    
@@ -34,18 +34,18 @@ public func parsePath(_ pathString: String) throws -> URL {
 
 /// Parses and validates a download URL string.
 /// Checks that the URL is valid, has a valid scheme (http or https) and has a valid host.
-public func parseUrl(_ urlString: String) throws -> URL {
+public func parseURL(_ urlString: String) throws -> URL {
    guard let url = URL(string: urlString) else {
-      throw DownloadError.invalidUrl("Invalid URL: \(urlString)")
+      throw DownloadError.invalidURL("Invalid URL: \(urlString)")
    }
    
    let scheme = url.scheme?.lowercased()
    guard scheme == "http" || scheme == "https" else {
-      throw DownloadError.invalidUrl("Invalid URL scheme '\(scheme ?? "none")': must be http or https")
+      throw DownloadError.invalidURL("Invalid URL scheme '\(scheme ?? "none")': must be http or https")
    }
    
    guard let host = url.host, !host.isEmpty else {
-      throw DownloadError.invalidUrl("URL must have a host")
+      throw DownloadError.invalidURL("URL must have a host")
    }
    
    return url

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/URLParserTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/URLParserTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import DownloadManagerKit
 
-final class UrlParserTests: XCTestCase {
+final class URLParserTests: XCTestCase {
 
    // MARK: - parsePath tests
 
@@ -25,29 +25,29 @@ final class UrlParserTests: XCTestCase {
       XCTAssertThrowsError(try parsePath("/"))
    }
 
-   // MARK: - parseUrl tests
+   // MARK: - parseURL tests
 
    func testValidUrls() throws {
-      XCTAssertNoThrow(try parseUrl("https://example.com/file.mp4"))
-      XCTAssertNoThrow(try parseUrl("http://example.com/file.mp4"))
-      XCTAssertNoThrow(try parseUrl("https://example.com:8080/file.mp4"))
-      XCTAssertNoThrow(try parseUrl("https://example.com/file.mp4?token=abc"))
+      XCTAssertNoThrow(try parseURL("https://example.com/file.mp4"))
+      XCTAssertNoThrow(try parseURL("http://example.com/file.mp4"))
+      XCTAssertNoThrow(try parseURL("https://example.com:8080/file.mp4"))
+      XCTAssertNoThrow(try parseURL("https://example.com/file.mp4?token=abc"))
    }
 
    func testEmptyUrl() {
-      XCTAssertThrowsError(try parseUrl(""))
+      XCTAssertThrowsError(try parseURL(""))
    }
 
    func testInvalidScheme() {
-      XCTAssertThrowsError(try parseUrl("ftp://example.com/file.mp4"))
-      XCTAssertThrowsError(try parseUrl("file:///path/to/file.mp4"))
+      XCTAssertThrowsError(try parseURL("ftp://example.com/file.mp4"))
+      XCTAssertThrowsError(try parseURL("file:///path/to/file.mp4"))
    }
 
    func testMissingHost() {
-      XCTAssertThrowsError(try parseUrl("https://:8080/file.mp4"))
+      XCTAssertThrowsError(try parseURL("https://:8080/file.mp4"))
    }
 
    func testInvalidUrlFormat() {
-      XCTAssertThrowsError(try parseUrl("not a valid url"))
+      XCTAssertThrowsError(try parseURL("not a valid url"))
    }
 }

--- a/ios/Sources/DownloadPlugin.swift
+++ b/ios/Sources/DownloadPlugin.swift
@@ -47,7 +47,7 @@ class DownloadPlugin: Plugin {
    @objc public func create(_ invoke: Invoke) throws {
       let args = try invoke.parseArgs(CreateArgs.self)
       let path = try parsePath(args.path)
-      let url = try parseUrl(args.url)
+      let url = try parseURL(args.url)
       Task {
          let response = await self.downloadManager.create(path: path, url: url)
          invoke.resolve(response)

--- a/src/models.rs
+++ b/src/models.rs
@@ -38,7 +38,7 @@ mod mobile_types {
       Idle,
       InProgress,
       Paused,
-      Cancelled,
+      Canceled,
       Completed,
    }
 


### PR DESCRIPTION
## Summary

Align naming conventions across all platforms (Rust, TypeScript, Swift, Kotlin) to conform with
[Silvermine coding standards](https://github.com/silvermine/silvermine-info/blob/master/coding-standards.md).

Resolves #35 and #36.

### Changes

**American English spelling (#35)**
- `Cancelled` / `cancelled` → `Canceled` / `canceled` across all platforms
- `cancelling` → `canceling`
- `serialises` → `serializes` (Swift comment)

**Acronym casing (Silvermine standards)**
- `parseUrl` → `parseURL` (Swift), `parseURI` (Kotlin, to match `java.net.URI`)
- `invalidUrl` → `invalidURL`, `fileUrl` → `fileURL`, `downloadUrl` → `downloadURL`
- `updateUrl` → `updateURL`
- `notificationId` → `notificationID`
- `UrlParser` → `URLParser.swift` / `URIParser.kt` (file renames)
- `UrlParserTests` → `URLParserTests.swift` / `URIParserTest.kt` (file renames)

**Compound word consistency**
- `fileName` → `filename` in Swift and Kotlin parsers (standardized to match existing usage
  throughout the rest of the codebase)

**Line endings (#36)**
- Added `.gitattributes` with `* text=auto eol=lf` to enforce LF line endings across platforms

### Breaking changes

- The serialized `DownloadStatus` value changed from `"cancelled"` to `"canceled"` across all
  platforms (Rust serde, TypeScript enum, Kotlin `@SerialName`, Swift `Codable`).
- The TypeScript `DownloadStatus.Cancelled` enum member is now `DownloadStatus.Canceled`.

## Test plan

- [x] Rust: `cargo test --workspace --lib` — 32 passed
- [x] TypeScript: `vitest run` — 18 passed
- [x] Swift: `swift test` — 9 passed
- [x] Kotlin: `./gradlew :lib:test` — BUILD SUCCESSFUL
- [x] Grep for old spellings (`cancelled`, `Cancelled`, `cancelling`, `serialises`, `parseUrl`,
  `invalidUrl`, `fileUrl`, `downloadUrl`, `updateUrl`, `notificationId`, `UrlParser`, `fileName`)
  returns zero matches