### PR TITLE
fix: replace @tauri-apps/api peer dep with minimum version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
             "vitest": "3.2.3"
          },
          "peerDependencies": {
-            "@tauri-apps/api": "2.9.1"
+            "@tauri-apps/api": "^2.9.0"
          }
       },
       "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
       "vitest": "3.2.3"
    },
    "peerDependencies": {
-      "@tauri-apps/api": "2.9.1"
+      "@tauri-apps/api": "^2.9.0"
    }
 }


### PR DESCRIPTION
Exact peer dep on `@tauri-apps/api` caused `npm ci` to fail in consuming projects that use a different minor version.

- Use caret peer dependency of ^2.9.0