### PR TITLE
build: bump Rust version to 1.94.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
          - name: Setup Rust toolchain
            uses: actions-rust-lang/setup-rust-toolchain@v1
            with:
-              toolchain: '1.89.0'
+              toolchain: '1.94.0'
               components: rustfmt, clippy
               cache: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Resumable download manager for Tauri applications"
 license = "MIT"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.94.0"
 links = "tauri-plugin-download"
 exclude = ["/examples", "/dist-js", "/guest-js", "/node_modules"]
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cd android && ./gradlew :lib:test
 
 ## Install
 
-_This plugin requires a Rust version of at least **1.77.2**_
+_This plugin requires a Rust version of at least **1.94.0**_
 
 ### Rust
 

--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Cross-platform resumable download manager"
 license = "MIT"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.94.0"
 
 [dependencies]
 futures = "0.3.31"

--- a/examples/tauri-app/src-tauri/Cargo.toml
+++ b/examples/tauri-app/src-tauri/Cargo.toml
@@ -3,7 +3,8 @@ name = "tauri-app"
 version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
-edition = "2021"
+edition = "2024"
+rust-version = "1.94.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.94.0"
 components = [
    "rustfmt",
    "clippy"


### PR DESCRIPTION
## Summary

Bumps the project's Rust version to **1.94.0** to match the updated Silvermine standard (silvermine/silvermine-info#47).

Updated the version in all locations:

- `rust-toolchain.toml` channel
- `rust-version` in the workspace `Cargo.toml` and `crates/download-manager`
- README install note (was `1.77.2`)
- CI workflow toolchain (`.github/workflows/ci.yml`)

The example app (`examples/tauri-app/src-tauri`) was also brought in line with the Silvermine standard: bumped `edition` from `2021` to `2024` and added `rust-version = "1.94.0"`.

Verified `npm run standards` passes and both the workspace and the example app compile cleanly with the 1.94.0 toolchain.code)