### PR TITLE
refactor: persist the http client on the DownloadManager

### DIFF
--- a/crates/download-manager/src/downloader.rs
+++ b/crates/download-manager/src/downloader.rs
@@ -1,7 +1,5 @@
 use futures::StreamExt;
 use reqwest::header::{HeaderMap, RANGE};
-use reqwest_middleware::ClientBuilder;
-use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
@@ -19,12 +17,6 @@ use crate::models::*;
 /// - Progress tracking and throttling
 /// - State updates and event emission
 pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> crate::Result<()> {
-   // Build client with retry middleware for transient failures.
-   let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
-   let client = ClientBuilder::new(reqwest::Client::new())
-      .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-      .build();
-
    // Check the size of the already downloaded part, if any.
    let temp_path = format!("{}{}", item.path, DOWNLOAD_SUFFIX);
    let mut downloaded_size = if Path::new(&temp_path).exists() {
@@ -47,7 +39,13 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
    }
 
    // Send the request.
-   let response = match client.get(&item.url).headers(headers).send().await {
+   let response = match manager
+      .http_client
+      .get(&item.url)
+      .headers(headers)
+      .send()
+      .await
+   {
       Ok(res) => res,
       Err(e) => {
          return Err(Error::Http(format!("Failed to send request: {}", e)));
@@ -82,10 +80,7 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
 
    // Get the total size of the file from headers (if available).
    let total_size = response
-      .headers()
-      .get("content-length")
-      .and_then(|len| len.to_str().ok())
-      .and_then(|len| len.parse::<u64>().ok())
+      .content_length()
       .map(|len| len + downloaded_size)
       .unwrap_or(0);
 

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -1,3 +1,5 @@
+use reqwest_middleware::ClientBuilder;
+use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -9,6 +11,8 @@ use crate::models::*;
 use crate::store::DownloadStore;
 use crate::validate;
 
+type HttpClient = reqwest_middleware::ClientWithMiddleware;
+
 pub(crate) static DOWNLOAD_SUFFIX: &str = ".download";
 
 /// Callback invoked whenever a download item changes state.
@@ -17,6 +21,7 @@ pub type OnChanged = Arc<dyn Fn(DownloadItem) + Send + Sync + 'static>;
 /// Tauri-agnostic download manager, mirroring the iOS/Android `DownloadManager`.
 #[derive(Clone)]
 pub struct DownloadManager {
+   pub(crate) http_client: HttpClient,
    pub(crate) store: DownloadStore,
    pub(crate) on_changed: OnChanged,
 }
@@ -32,7 +37,16 @@ impl DownloadManager {
       if let Err(e) = store.load() {
          warn!("Failed to load download store: {}", e);
       }
-      Self { store, on_changed }
+      // Build client with retry middleware for transient failures.
+      let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+      let http_client = ClientBuilder::new(reqwest::Client::new())
+         .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+         .build();
+      Self {
+         http_client,
+         store,
+         on_changed,
+      }
    }
 
    ///


### PR DESCRIPTION
I noticed that every download was recreating the client, which meant it could never share the connection pool, would need to rebuild the TLS context, etc. This now reuses the client for the lifetime of the download manager.

r? @velocitysystems 