### PR TITLE
refactor: emit bytesReceived instead of a progress percent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 State-driven, resumable download API for Tauri 2.x apps.
 
 This plugin provides a cross-platform download interface with resumable downloads,
-progress tracking, and proper resource management.
+byte-count progress tracking, and proper resource management.
 
 [ci-badge]: https://github.com/silvermine/tauri-plugin-download/actions/workflows/ci.yml/badge.svg
 [ci-url]: https://github.com/silvermine/tauri-plugin-download/actions/workflows/ci.yml
@@ -14,7 +14,7 @@ progress tracking, and proper resource management.
 
    * Parallel, resumable download support
    * Persistable, thread-safe store
-   * State and progress notifications
+   * State, byte count, and progress notifications
    * Cross-platform support (Linux, Windows, macOS, Android, iOS)
 
 | Platform  | Supported |
@@ -126,7 +126,11 @@ async function listDownloads() {
    const downloads = await list();
 
    for (const download of downloads) {
-      console.debug(`Found '${download.path}': [${download.status}, ${download.progress}%]`);
+      const totalBytes = download.totalBytes ?? 'unknown';
+
+      console.debug(
+         `Found '${download.path}': [${download.status}, ${download.receivedBytes}/${totalBytes} bytes, ${download.progress}%]`
+      );
    }
 }
 ```
@@ -142,7 +146,11 @@ async function getDownload() {
    if (download.status === DownloadStatus.Pending) {
       console.debug(`Download '${download.path}' not found in store`);
    } else {
-      console.debug(`Found '${download.path}': [${download.status}, ${download.progress}%]`);
+      const totalBytes = download.totalBytes ?? 'unknown';
+
+      console.debug(
+         `Found '${download.path}': [${download.status}, ${download.receivedBytes}/${totalBytes} bytes, ${download.progress}%]`
+      );
    }
 }
 ```
@@ -182,6 +190,9 @@ async function manageDownload() {
 
 Listeners can be attached to downloads in any status, including `Pending`.
 This allows you to set up listeners before creating the download.
+Each download state includes `receivedBytes`, `totalBytes`, and `progress`.
+When the server does not provide a content length, `totalBytes` is `null`;
+`progress` remains `0` until the terminal `Completed` event, where it is `100`.
 
 ```ts
 import { get, DownloadStatus } from 'tauri-plugin-download';
@@ -191,7 +202,9 @@ async function setupAndStartDownload() {
 
    // Attach listener (works for Pending downloads too)
    const unlisten = await download.listen((updated) => {
-      console.debug(`'${updated.path}': ${updated.progress}%`);
+      console.debug(
+         `'${updated.path}': ${updated.receivedBytes}/${updated.totalBytes ?? 'unknown'} bytes (${updated.progress}%)`
+      );
    });
 
    // Create and start if pending
@@ -236,9 +249,12 @@ It is not a backend contract and does not transition downloads to `Completed`.
 Use `emitChange()` to simulate progress updates or terminal-state events, or
 `setDownload()` to seed a specific state without emitting an event.
 It only simulates the desktop event path and returns `false` for `is_native`,
-so tests for the native/mobile listener branch need a separate approach. When
-emitting a `Completed` state, include `progress: 100` yourself because the mock
-does not normalize terminal-state progress.
+so tests for the native/mobile listener branch need a separate approach.
+
+`createMockDownloadState()` computes `progress` from `receivedBytes` and
+`totalBytes` when `progress` is not explicitly provided. For unknown-size
+downloads, use `totalBytes: null`. A generated `Completed` state reports
+`progress: 100`.
 
 ```ts
 import { afterEach, expect, it } from 'vitest';

--- a/crates/download-manager/src/downloader.rs
+++ b/crates/download-manager/src/downloader.rs
@@ -16,7 +16,7 @@ use crate::models::*;
 /// - Streaming response chunks to disk
 /// - Progress tracking and throttling
 /// - State updates and event emission
-pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> crate::Result<()> {
+pub(crate) async fn download(manager: &DownloadManager, item: DownloadRecord) -> crate::Result<()> {
    // Check the size of the already downloaded part, if any.
    let temp_path = format!("{}{}", item.path, DOWNLOAD_SUFFIX);
    let mut downloaded_size = if Path::new(&temp_path).exists() {
@@ -79,10 +79,20 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
    }
 
    // Get the total size of the file from headers (if available).
-   let total_size = response
-      .content_length()
-      .map(|len| len + downloaded_size)
-      .unwrap_or(0);
+   let total_size = response.content_length().map(|len| len + downloaded_size);
+
+   // Persist a known total immediately. Progress updates deliberately avoid disk
+   // writes, but the total must survive an abrupt process exit so init() can
+   // combine it with the recovered temp-file length.
+   if let Some(total) = total_size
+      && let Some(current_item) = manager.store.find_by_path(&item.path)?
+      && current_item.status == DownloadStatus::InProgress
+      && current_item.total_bytes != Some(total)
+   {
+      manager
+         .store
+         .update(current_item.with_bytes(downloaded_size, Some(total)))?;
+   }
 
    // Ensure the output folder exists.
    let folder = Path::new(&temp_path)
@@ -101,16 +111,8 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
       .map_err(|e| Error::File(format!("Failed to open file: {}", e)))?;
 
    // Write the response body to the file in chunks.
-   let mut downloaded = downloaded_size;
    let mut stream = response.bytes_stream();
-
-   // Throttle progress updates:
-   // - Known size: emit when progress increases by at least 1%.
-   // - Unknown size: emit every BYTES_THRESHOLD bytes.
-   let mut last_emitted_progress = 0.0;
-   let mut last_emitted_bytes = downloaded_size;
-   const PROGRESS_THRESHOLD: f64 = 1.0;
-   const BYTES_THRESHOLD: u64 = 1024 * 1024;
+   let mut progress = ProgressTracker::new(downloaded_size, total_size);
 
    while let Some(chunk) = stream.next().await {
       match chunk {
@@ -119,24 +121,13 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
                .write_all(&data)
                .map_err(|e| Error::File(format!("Failed to write file: {}", e)))?;
 
-            downloaded += data.len() as u64;
-            let progress = if total_size > 0 {
-               (downloaded as f64 / total_size as f64) * 100.0
-            } else {
-               0.0
-            };
+            progress.advance(data.len() as u64);
 
-            let should_throttle = if total_size > 0 {
-               progress < 100.0 && progress - last_emitted_progress <= PROGRESS_THRESHOLD
-            } else {
-               downloaded - last_emitted_bytes < BYTES_THRESHOLD
-            };
-            if should_throttle {
+            if !progress.should_emit() {
                continue;
             }
 
-            last_emitted_progress = progress;
-            last_emitted_bytes = downloaded;
+            progress.mark_emitted();
             let Ok(Some(current_item)) = manager.store.find_by_path(&item.path) else {
                // Download item was not found i.e. removed.
                return Ok(());
@@ -144,12 +135,14 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
             match current_item.status {
                // Download is in progress.
                DownloadStatus::InProgress => {
-                  if progress < 100.0 {
+                  if !progress.is_complete() {
                      // Download is not yet complete.
                      // Update item in store and emit change event.
-                     let updated = current_item.with_progress(progress);
+                     let updated = current_item
+                        .with_bytes(progress.received_bytes, total_size)
+                        .with_status(DownloadStatus::InProgress);
                      manager.store.update_no_persist(updated.clone())?;
-                     manager.emit_changed(updated);
+                     manager.emit_changed(&updated);
                   }
                   // Completion is handled after the loop exits naturally.
                }
@@ -188,10 +181,71 @@ pub(crate) async fn download(manager: &DownloadManager, item: DownloadItem) -> c
 
       // File is safely in place; now drop the store entry and signal completion.
       manager.store.delete(&item.path)?;
-      manager.emit_changed(current_item.with_status(DownloadStatus::Completed));
+      let completed = current_item
+         .with_bytes(progress.received_bytes, total_size)
+         .with_status(DownloadStatus::Completed);
+      manager.emit_changed(&completed);
    }
 
    Ok(())
+}
+
+/// Tracks download progress and controls when emissions are sent.
+///
+/// - Known size (`total_bytes` is `Some`): emits when the integer percent (0–100) changes.
+/// - Unknown size (`None`): emits every `BYTES_THRESHOLD` bytes.
+///
+/// Tracks `received_bytes` internally so the download loop only needs to call
+/// `advance()` with each chunk size and check `should_emit()`.
+struct ProgressTracker {
+   received_bytes: u64,
+   total_bytes: Option<u64>,
+   last_emitted_percent: u64,
+   last_emitted_bytes: u64,
+}
+
+impl ProgressTracker {
+   const BYTES_THRESHOLD: u64 = 1024 * 1024;
+
+   fn new(received_bytes: u64, total_bytes: Option<u64>) -> Self {
+      let last_emitted_percent = match total_bytes {
+         Some(total) if total > 0 => received_bytes * 100 / total,
+         _ => 0,
+      };
+      Self {
+         received_bytes,
+         total_bytes,
+         last_emitted_percent,
+         last_emitted_bytes: received_bytes,
+      }
+   }
+
+   fn advance(&mut self, bytes_written: u64) {
+      self.received_bytes += bytes_written;
+   }
+
+   fn should_emit(&self) -> bool {
+      match self.total_bytes {
+         Some(total) if total > 0 => {
+            let percent = self.received_bytes * 100 / total;
+            percent >= 100 || percent > self.last_emitted_percent
+         }
+         _ => self.received_bytes - self.last_emitted_bytes >= Self::BYTES_THRESHOLD,
+      }
+   }
+
+   fn is_complete(&self) -> bool {
+      matches!(self.total_bytes, Some(total) if self.received_bytes >= total)
+   }
+
+   fn mark_emitted(&mut self) {
+      if let Some(total) = self.total_bytes
+         && total > 0
+      {
+         self.last_emitted_percent = self.received_bytes * 100 / total;
+      }
+      self.last_emitted_bytes = self.received_bytes;
+   }
 }
 
 #[cfg(test)]
@@ -216,8 +270,8 @@ mod tests {
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
       let captured = events.clone();
-      let on_changed: OnChanged = Arc::new(move |item| {
-         captured.lock().unwrap().push(item);
+      let on_changed: OnChanged = Arc::new(move |event| {
+         captured.lock().unwrap().push(event);
       });
       let manager = DownloadManager::new(dir.path().to_path_buf(), on_changed);
       TestFixture {
@@ -227,13 +281,14 @@ mod tests {
       }
    }
 
-   /// Seeds an `InProgress` item in the store and returns a `DownloadItem`
+   /// Seeds an `InProgress` record in the store and returns a `DownloadRecord`
    /// suitable for passing to `download()`.
-   fn seed_in_progress(manager: &DownloadManager, dest_path: &str, url: &str) -> DownloadItem {
-      let item = DownloadItem {
+   fn seed_in_progress(manager: &DownloadManager, dest_path: &str, url: &str) -> DownloadRecord {
+      let item = DownloadRecord {
          url: url.to_string(),
          path: dest_path.to_string(),
-         progress: 0.0,
+         received_bytes: 0,
+         total_bytes: None,
          status: DownloadStatus::InProgress,
       };
       manager.store.create(item.clone()).unwrap();
@@ -288,11 +343,22 @@ mod tests {
          events_with_status(&fixture.events, DownloadStatus::Completed),
          1
       );
+
+      let completed = fixture
+         .events
+         .lock()
+         .unwrap()
+         .iter()
+         .find(|e| e.status == DownloadStatus::Completed)
+         .cloned()
+         .unwrap();
+      assert_eq!(completed.received_bytes, body.len() as u64);
+      assert_eq!(completed.total_bytes, Some(body.len() as u64));
    }
 
    #[tokio::test]
    async fn test_completes_without_content_length() {
-      // Regression: when the server omits Content-Length, total_size is 0
+      // Regression: when the server omits Content-Length, total_size is None
       // and progress stays at 0.0. Completion must still trigger when the
       // stream ends naturally.
       let fixture = make_fixture();
@@ -321,6 +387,17 @@ mod tests {
          events_with_status(&fixture.events, DownloadStatus::Completed),
          1
       );
+
+      let completed = fixture
+         .events
+         .lock()
+         .unwrap()
+         .iter()
+         .find(|e| e.status == DownloadStatus::Completed)
+         .cloned()
+         .unwrap();
+      assert_eq!(completed.received_bytes, body.len() as u64);
+      assert_eq!(completed.total_bytes, None);
    }
 
    #[tokio::test]
@@ -353,6 +430,17 @@ mod tests {
 
       let combined = [first_half.as_slice(), second_half.as_slice()].concat();
       assert_eq!(fs::read(&dest).unwrap(), combined);
+
+      let completed = fixture
+         .events
+         .lock()
+         .unwrap()
+         .iter()
+         .find(|e| e.status == DownloadStatus::Completed)
+         .cloned()
+         .unwrap();
+      assert_eq!(completed.received_bytes, combined.len() as u64);
+      assert_eq!(completed.total_bytes, Some(combined.len() as u64));
    }
 
    #[tokio::test]
@@ -383,6 +471,17 @@ mod tests {
       assert_eq!(fs::read(&dest).unwrap(), full_body);
       // Temp file has been cleaned up.
       assert!(!Path::new(&temp_path).exists());
+
+      let completed = fixture
+         .events
+         .lock()
+         .unwrap()
+         .iter()
+         .find(|e| e.status == DownloadStatus::Completed)
+         .cloned()
+         .unwrap();
+      assert_eq!(completed.received_bytes, full_body.len() as u64);
+      assert_eq!(completed.total_bytes, Some(full_body.len() as u64));
    }
 
    #[tokio::test]
@@ -462,13 +561,14 @@ mod tests {
 
       download(&fixture.manager, item).await.unwrap();
 
-      // At least one InProgress progress event with progress == 0.0 (unknown size),
-      // plus the final Completed event.
+      // At least one InProgress event with received_bytes > 0 but total_bytes == None
+      // (unknown size), plus the final Completed event.
       let log = fixture.events.lock().unwrap().clone();
       assert!(
-         log.iter()
-            .any(|e| e.status == DownloadStatus::InProgress && e.progress == 0.0),
-         "expected at least one InProgress(0.0) progress event for unknown size"
+         log.iter().any(|e| e.status == DownloadStatus::InProgress
+            && e.received_bytes > 0
+            && e.total_bytes.is_none()),
+         "expected at least one InProgress event with received_bytes > 0 for unknown size"
       );
       assert_eq!(
          events_with_status(&fixture.events, DownloadStatus::Completed),
@@ -481,7 +581,7 @@ mod tests {
       // Flipping the status to Paused while the body is still streaming must
       // stop reading, skip completion, and leave the .download temp file intact
       // so the download can later resume. The body exceeds BYTES_THRESHOLD so the
-      // in-loop throttle checkpoint — where the status is re-read from the store —
+      // in-loop progress checkpoint — where the status is re-read from the store —
       // is reached while data still remains, exercising the in-loop transition.
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
@@ -493,14 +593,17 @@ mod tests {
       let store_cell: Arc<Mutex<Option<DownloadStore>>> = Arc::new(Mutex::new(None));
       let captured = events.clone();
       let cell = store_cell.clone();
-      let on_changed: OnChanged = Arc::new(move |item: DownloadItem| {
-         captured.lock().unwrap().push(item.clone());
-         if item.status == DownloadStatus::InProgress
+      let on_changed: OnChanged = Arc::new(move |event: DownloadItem| {
+         captured.lock().unwrap().push(event.clone());
+         if event.status == DownloadStatus::InProgress
             && let Some(store) = cell.lock().unwrap().as_ref()
          {
-            store
-               .update_no_persist(item.with_status(DownloadStatus::Paused))
-               .unwrap();
+            // Re-read the record from the store to get a DownloadRecord for with_status
+            if let Ok(Some(item)) = store.find_by_path(&event.path) {
+               store
+                  .update_no_persist(item.with_status(DownloadStatus::Paused))
+                  .unwrap();
+            }
          }
       });
 
@@ -509,7 +612,7 @@ mod tests {
 
       let server = MockServer::start().await;
       // Several times BYTES_THRESHOLD with unknown size, so the body is delivered
-      // over multiple stream chunks and several throttle checkpoints are reached.
+      // over multiple stream chunks and several progress checkpoints are reached.
       let body = vec![0u8; 4 * 1024 * 1024];
       Mock::given(method("GET"))
          .and(wm_path("/pause"))
@@ -579,6 +682,16 @@ mod tests {
       // Store entry survives and is still InProgress, ready to be reverted/resumed.
       let stored = fixture.manager.store.find_by_path(&dest).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::InProgress);
+      assert_eq!(stored.total_bytes, Some(b"complete body".len() as u64));
+
+      // The total was written to disk when the response headers arrived, not only
+      // retained by the in-memory progress updates.
+      let reloaded = DownloadStore::new(fixture._dir.path().join("downloads.json"));
+      reloaded.load().unwrap();
+      assert_eq!(
+         reloaded.find_by_path(&dest).unwrap().unwrap().total_bytes,
+         Some(b"complete body".len() as u64)
+      );
       // Temp file is left intact rather than orphaned and forgotten.
       assert!(Path::new(&format!("{}{}", dest, DOWNLOAD_SUFFIX)).exists());
       // No completion event was emitted.

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -83,7 +83,12 @@ impl DownloadManager {
    /// # Returns
    /// The list of download operations.
    pub fn list(&self) -> crate::Result<Vec<DownloadItem>> {
-      self.store.list()
+      Ok(self
+         .store
+         .list()?
+         .into_iter()
+         .map(|i| i.to_item())
+         .collect())
    }
 
    ///
@@ -102,13 +107,15 @@ impl DownloadManager {
       validate::path(path)?;
 
       match self.store.find_by_path(path)? {
-         Some(item) => Ok(item),
-         None => Ok(DownloadItem {
+         Some(item) => Ok(item.to_item()),
+         None => Ok(DownloadRecord {
             url: String::new(),
             path: path.to_string(),
-            progress: 0.0,
+            received_bytes: 0,
+            total_bytes: None,
             status: DownloadStatus::Pending,
-         }),
+         }
+         .to_item()),
       }
    }
 
@@ -128,20 +135,21 @@ impl DownloadManager {
       // Check if item already exists
       if let Some(existing) = self.store.find_by_path(path)? {
          return Ok(DownloadActionResponse::with_expected_status(
-            existing,
+            existing.to_item(),
             DownloadStatus::Idle,
          ));
       }
 
-      let item = self.store.create(DownloadItem {
+      let item = self.store.create(DownloadRecord {
          url: url.to_string(),
          path: path.to_string(),
-         progress: 0.0,
+         received_bytes: 0,
+         total_bytes: None,
          status: DownloadStatus::Idle,
       })?;
 
-      self.emit_changed(item.clone());
-      Ok(DownloadActionResponse::new(item))
+      let event = self.emit_changed(&item);
+      Ok(DownloadActionResponse::new(event))
    }
 
    ///
@@ -165,7 +173,7 @@ impl DownloadManager {
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
-            item,
+            item.to_item(),
             DownloadStatus::InProgress,
          )),
       }
@@ -192,7 +200,7 @@ impl DownloadManager {
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
-            item,
+            item.to_item(),
             DownloadStatus::InProgress,
          )),
       }
@@ -200,7 +208,7 @@ impl DownloadManager {
 
    fn spawn_download(
       &self,
-      item: DownloadItem,
+      item: DownloadRecord,
       err_msg: &'static str,
    ) -> crate::Result<DownloadActionResponse> {
       let item_in_progress = item.with_status(DownloadStatus::InProgress);
@@ -208,7 +216,8 @@ impl DownloadManager {
 
       let manager = self.clone();
       let path = item.path.clone();
-      let item_in_progress_response = item_in_progress.clone();
+      // Build the item without emitting — the download task will emit progress updates.
+      let public_item = item_in_progress.to_item();
       tokio::spawn(async move {
          if let Err(e) = downloader::download(&manager, item_in_progress).await {
             error!(file = %filename(&path), "Download {}: {}", err_msg, e);
@@ -227,7 +236,7 @@ impl DownloadManager {
          }
       });
 
-      Ok(DownloadActionResponse::new(item_in_progress_response))
+      Ok(DownloadActionResponse::new(public_item))
    }
 
    ///
@@ -250,13 +259,13 @@ impl DownloadManager {
          DownloadStatus::InProgress => {
             let paused = item.with_status(DownloadStatus::Paused);
             self.store.update(paused.clone())?;
-            self.emit_changed(paused.clone());
-            Ok(DownloadActionResponse::new(paused))
+            let event = self.emit_changed(&paused);
+            Ok(DownloadActionResponse::new(event))
          }
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
-            item,
+            item.to_item(),
             DownloadStatus::Paused,
          )),
       }
@@ -286,42 +295,48 @@ impl DownloadManager {
                debug!(file = %filename(&item.path), "Temp file was not found or could not be deleted");
             }
 
-            self.emit_changed(item.with_status(DownloadStatus::Canceled));
-            Ok(DownloadActionResponse::new(
-               item.with_status(DownloadStatus::Canceled),
-            ))
+            let canceled = item.with_status(DownloadStatus::Canceled);
+            let event = self.emit_changed(&canceled);
+            Ok(DownloadActionResponse::new(event))
          }
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
-            item,
+            item.to_item(),
             DownloadStatus::Canceled,
          )),
       }
    }
 
-   /// Reverts an `InProgress` download item to `Paused` or `Idle` based on
+   /// Reverts an `InProgress` download record to `Paused` or `Idle` based on
    /// whether a temp file exists on disk. No-op for other statuses.
-   fn revert_in_progress(&self, item: &DownloadItem) -> crate::Result<DownloadItem> {
+   fn revert_in_progress(&self, item: &DownloadRecord) -> crate::Result<DownloadRecord> {
       if item.status != DownloadStatus::InProgress {
          return Ok(item.clone());
       }
 
       let temp_path = format!("{}{}", item.path, DOWNLOAD_SUFFIX);
-      let reverted = if Path::new(&temp_path).exists() {
-         item.with_status(DownloadStatus::Paused)
+      let reverted = if let Ok(meta) = fs::metadata(&temp_path) {
+         // Metadata succeeded, so the temp file exists — recover byte count from it.
+         item
+            .with_bytes(meta.len(), item.total_bytes)
+            .with_status(DownloadStatus::Paused)
       } else {
-         item.with_status(DownloadStatus::Idle)
+         item
+            .with_bytes(0, item.total_bytes)
+            .with_status(DownloadStatus::Idle)
       };
 
       self.store.update(reverted.clone())?;
-      self.emit_changed(reverted.clone());
+      self.emit_changed(&reverted);
       Ok(reverted)
    }
 
-   pub(crate) fn emit_changed(&self, item: DownloadItem) {
-      debug!(file = %filename(&item.path), status = %item.status, progress = item.progress);
-      (self.on_changed)(item);
+   pub(crate) fn emit_changed(&self, item: &DownloadRecord) -> DownloadItem {
+      let public_item = item.to_item();
+      debug!(file = %filename(&item.path), status = %item.status, received_bytes = item.received_bytes, total_bytes = ?item.total_bytes);
+      (self.on_changed)(public_item.clone());
+      public_item
    }
 }
 
@@ -346,8 +361,8 @@ mod tests {
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
       let captured = events.clone();
-      let on_changed: OnChanged = Arc::new(move |item| {
-         captured.lock().unwrap().push(item);
+      let on_changed: OnChanged = Arc::new(move |event| {
+         captured.lock().unwrap().push(event);
       });
       let manager = DownloadManager::new(dir.path().to_path_buf(), on_changed);
       (manager, dir, events)
@@ -364,10 +379,11 @@ mod tests {
    fn seed(manager: &DownloadManager, path: &str, status: DownloadStatus) {
       manager
          .store
-         .create(DownloadItem {
+         .create(DownloadRecord {
             url: VALID_URL.to_string(),
             path: path.to_string(),
-            progress: 0.0,
+            received_bytes: 0,
+            total_bytes: None,
             status,
          })
          .unwrap();
@@ -382,7 +398,8 @@ mod tests {
       assert_eq!(item.path, "/tmp/unknown.mp4");
       assert_eq!(item.status, DownloadStatus::Pending);
       assert_eq!(item.url, "");
-      assert_eq!(item.progress, 0.0);
+      assert_eq!(item.received_bytes, 0);
+      assert_eq!(item.total_bytes, None);
    }
 
    #[test]
@@ -675,6 +692,7 @@ mod tests {
 
       let stored = manager.store.find_by_path(&path).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::Paused);
+      assert_eq!(stored.received_bytes, b"partial".len() as u64);
 
       assert!(
          event_log(&events)
@@ -688,11 +706,20 @@ mod tests {
       let (manager, dir, _events) = make_manager();
       let path = dir.path().join("file.mp4").to_string_lossy().to_string();
       seed(&manager, &path, DownloadStatus::InProgress);
+      let stale = manager
+         .store
+         .find_by_path(&path)
+         .unwrap()
+         .unwrap()
+         .with_bytes(500, Some(1000));
+      manager.store.update(stale).unwrap();
 
       manager.init();
 
       let stored = manager.store.find_by_path(&path).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::Idle);
+      assert_eq!(stored.received_bytes, 0);
+      assert_eq!(stored.total_bytes, Some(1000));
    }
 
    #[test]

--- a/crates/download-manager/src/models.rs
+++ b/crates/download-manager/src/models.rs
@@ -1,11 +1,31 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+/// Persisted download record. Stored in `downloads.json`.
+///
+/// Does not contain `progress` — that is a derived value only present in
+/// [`DownloadItem`], which is what gets sent to the frontend.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DownloadRecord {
+   pub url: String,
+   pub path: String,
+   #[serde(default)]
+   pub received_bytes: u64,
+   #[serde(default)]
+   pub total_bytes: Option<u64>,
+   pub status: DownloadStatus,
+}
+
+/// Public payload sent to the frontend. Built from a [`DownloadRecord`] with
+/// `progress` computed from `received_bytes` / `total_bytes`.
+#[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DownloadItem {
    pub url: String,
    pub path: String,
+   pub received_bytes: u64,
+   pub total_bytes: Option<u64>,
    pub progress: f64,
    pub status: DownloadStatus,
 }
@@ -30,7 +50,7 @@ pub enum DownloadStatus {
    Completed,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DownloadActionResponse {
    pub download: DownloadItem,
@@ -39,43 +59,56 @@ pub struct DownloadActionResponse {
 }
 
 impl DownloadActionResponse {
-   pub fn new(download: DownloadItem) -> Self {
-      let expected_status = download.status.clone();
+   pub fn new(item: DownloadItem) -> Self {
+      let expected_status = item.status.clone();
       Self {
-         download,
+         download: item,
          expected_status,
          is_expected_status: true,
       }
    }
 
-   pub fn with_expected_status(download: DownloadItem, expected_status: DownloadStatus) -> Self {
-      let is_expected_status = download.status == expected_status;
+   pub fn with_expected_status(item: DownloadItem, expected_status: DownloadStatus) -> Self {
+      let is_expected_status = item.status == expected_status;
       Self {
-         download,
+         download: item,
          expected_status,
          is_expected_status,
       }
    }
 }
 
-impl DownloadItem {
-   pub fn with_progress(&self, new_progress: f64) -> DownloadItem {
-      DownloadItem {
-         progress: new_progress,
-         status: DownloadStatus::InProgress,
+impl DownloadRecord {
+   pub fn with_bytes(&self, received_bytes: u64, total_bytes: Option<u64>) -> DownloadRecord {
+      DownloadRecord {
+         received_bytes,
+         total_bytes,
          ..self.clone()
       }
    }
 
-   pub fn with_status(&self, new_status: DownloadStatus) -> DownloadItem {
-      DownloadItem {
-         progress: if new_status == DownloadStatus::Completed {
-            100.0
-         } else {
-            self.progress
-         },
+   pub fn with_status(&self, new_status: DownloadStatus) -> DownloadRecord {
+      DownloadRecord {
          status: new_status,
          ..self.clone()
+      }
+   }
+
+   pub fn to_item(&self) -> DownloadItem {
+      let progress = match (&self.status, self.total_bytes) {
+         (DownloadStatus::Completed, _) => 100.0,
+         (_, Some(total)) if total > 0 => {
+            ((self.received_bytes as f64 / total as f64) * 100.0).clamp(0.0, 100.0)
+         }
+         _ => 0.0,
+      };
+      DownloadItem {
+         url: self.url.clone(),
+         path: self.path.clone(),
+         received_bytes: self.received_bytes,
+         total_bytes: self.total_bytes,
+         progress,
+         status: self.status.clone(),
       }
    }
 }
@@ -99,44 +132,110 @@ impl fmt::Display for DownloadStatus {
 mod tests {
    use super::*;
 
-   fn sample_item() -> DownloadItem {
-      DownloadItem {
+   fn sample_record() -> DownloadRecord {
+      DownloadRecord {
          url: "http://example.com/file.mp4".to_string(),
          path: "/tmp/file.mp4".to_string(),
-         progress: 0.0,
+         received_bytes: 0,
+         total_bytes: None,
          status: DownloadStatus::Idle,
       }
    }
 
    #[test]
-   fn test_download_item_with_progress() {
-      let item = sample_item();
-      let updated = item.with_progress(50.0);
-      assert_eq!(updated.progress, 50.0);
-      assert_eq!(updated.status, DownloadStatus::InProgress);
-      assert_eq!(updated.url, item.url);
-      assert_eq!(updated.path, item.path);
+   fn test_download_record_with_bytes() {
+      let record = sample_record();
+      let updated = record.with_bytes(500, Some(1000));
+      assert_eq!(updated.received_bytes, 500);
+      assert_eq!(updated.total_bytes, Some(1000));
+      assert_eq!(updated.status, DownloadStatus::Idle);
+      assert_eq!(updated.url, record.url);
+      assert_eq!(updated.path, record.path);
    }
 
    #[test]
-   fn test_download_item_with_status() {
-      let mut item = sample_item();
-      item.progress = 50.0;
+   fn test_download_record_with_status() {
+      let mut record = sample_record();
+      record.received_bytes = 500;
+      record.total_bytes = Some(1000);
 
-      // Preserves progress for non-completed status
-      let paused = item.with_status(DownloadStatus::Paused);
-      assert_eq!(paused.progress, 50.0);
+      // Preserves bytes for non-completed status
+      let paused = record.with_status(DownloadStatus::Paused);
+      assert_eq!(paused.received_bytes, 500);
+      assert_eq!(paused.total_bytes, Some(1000));
       assert_eq!(paused.status, DownloadStatus::Paused);
 
-      // Sets progress to 100 for completed status
-      let completed = item.with_status(DownloadStatus::Completed);
-      assert_eq!(completed.progress, 100.0);
+      // Status transitions preserve the factual byte counts, including completion.
+      let completed = record.with_status(DownloadStatus::Completed);
+      assert_eq!(completed.received_bytes, 500);
+      assert_eq!(completed.total_bytes, Some(1000));
       assert_eq!(completed.status, DownloadStatus::Completed);
+      assert_eq!(completed.to_item().progress, 100.0);
+   }
+
+   #[test]
+   fn test_with_status_completed_unknown_size() {
+      // Completed with unknown size preserves received_bytes
+      let mut record = sample_record();
+      record.received_bytes = 5000;
+      let completed = record.with_status(DownloadStatus::Completed);
+      assert_eq!(completed.received_bytes, 5000);
+      assert_eq!(completed.total_bytes, None);
+   }
+
+   #[test]
+   fn test_to_item_with_known_size() {
+      let mut record = sample_record();
+      record.received_bytes = 500;
+      record.total_bytes = Some(1000);
+      let item = record.to_item();
+      assert_eq!(item.progress, 50.0);
+      assert_eq!(item.received_bytes, 500);
+      assert_eq!(item.total_bytes, Some(1000));
+   }
+
+   #[test]
+   fn test_to_item_clamps_progress_to_100_percent() {
+      let mut record = sample_record();
+      record.received_bytes = 1500;
+      record.total_bytes = Some(1000);
+      assert_eq!(record.to_item().progress, 100.0);
+   }
+
+   #[test]
+   fn test_to_item_with_unknown_size() {
+      let record = sample_record();
+      let item = record.to_item();
+      assert_eq!(item.progress, 0.0);
+
+      // Completed with unknown size still reports 100%
+      let completed = record.with_status(DownloadStatus::Completed);
+      assert_eq!(completed.to_item().progress, 100.0);
+   }
+
+   #[test]
+   fn test_deserialize_with_byte_fields() {
+      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","receivedBytes":500,"totalBytes":1000,"status":"paused"}"#;
+      let record: DownloadRecord = serde_json::from_str(json).unwrap();
+      assert_eq!(record.received_bytes, 500);
+      assert_eq!(record.total_bytes, Some(1000));
+      // progress is derived via to_item(), not stored
+      assert_eq!(record.to_item().progress, 50.0);
+   }
+
+   #[test]
+   fn test_deserialize_without_byte_fields() {
+      // Old format without receivedBytes/totalBytes defaults to 0/None
+      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","status":"idle"}"#;
+      let record: DownloadRecord = serde_json::from_str(json).unwrap();
+      assert_eq!(record.received_bytes, 0);
+      assert_eq!(record.total_bytes, None);
    }
 
    #[test]
    fn test_download_action_response() {
-      let item = sample_item();
+      let record = sample_record();
+      let item = record.to_item();
 
       // new() sets is_expected_status to true
       let response = DownloadActionResponse::new(item.clone());

--- a/crates/download-manager/src/store.rs
+++ b/crates/download-manager/src/store.rs
@@ -2,9 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::{DownloadItem, Error};
+use crate::Error;
+use crate::models::DownloadRecord;
 
-/// Thread-safe JSON file store for download items, mirroring iOS `DownloadStore`.
+/// Thread-safe JSON file store for download records, mirroring iOS `DownloadStore`.
 #[derive(Clone, Debug)]
 pub struct DownloadStore {
    inner: Arc<Mutex<StoreInner>>,
@@ -12,7 +13,7 @@ pub struct DownloadStore {
 
 #[derive(Debug)]
 struct StoreInner {
-   downloads: Vec<DownloadItem>,
+   downloads: Vec<DownloadRecord>,
    path: PathBuf,
 }
 
@@ -27,7 +28,7 @@ impl DownloadStore {
       }
    }
 
-   pub fn list(&self) -> crate::Result<Vec<DownloadItem>> {
+   pub fn list(&self) -> crate::Result<Vec<DownloadRecord>> {
       let inner = self
          .inner
          .lock()
@@ -35,7 +36,7 @@ impl DownloadStore {
       Ok(inner.downloads.clone())
    }
 
-   pub fn find_by_path(&self, path: &str) -> crate::Result<Option<DownloadItem>> {
+   pub fn find_by_path(&self, path: &str) -> crate::Result<Option<DownloadRecord>> {
       let inner = self
          .inner
          .lock()
@@ -43,7 +44,7 @@ impl DownloadStore {
       Ok(inner.downloads.iter().find(|i| i.path == path).cloned())
    }
 
-   pub fn create(&self, item: DownloadItem) -> crate::Result<DownloadItem> {
+   pub fn create(&self, item: DownloadRecord) -> crate::Result<DownloadRecord> {
       let mut inner = self
          .inner
          .lock()
@@ -61,7 +62,7 @@ impl DownloadStore {
       Ok(item)
    }
 
-   pub fn update(&self, item: DownloadItem) -> crate::Result<()> {
+   pub fn update(&self, item: DownloadRecord) -> crate::Result<()> {
       let mut inner = self
          .inner
          .lock()
@@ -74,7 +75,7 @@ impl DownloadStore {
       Ok(())
    }
 
-   pub fn update_no_persist(&self, item: DownloadItem) -> crate::Result<()> {
+   pub fn update_no_persist(&self, item: DownloadRecord) -> crate::Result<()> {
       let mut inner = self
          .inner
          .lock()
@@ -150,11 +151,12 @@ mod tests {
       (store, dir)
    }
 
-   fn sample_item(path: &str) -> DownloadItem {
-      DownloadItem {
+   fn sample_record(path: &str) -> DownloadRecord {
+      DownloadRecord {
          url: "https://example.com/file.mp4".to_string(),
          path: path.to_string(),
-         progress: 0.0,
+         received_bytes: 0,
+         total_bytes: None,
          status: DownloadStatus::Idle,
       }
    }
@@ -168,15 +170,15 @@ mod tests {
    #[test]
    fn test_list_after_create() {
       let (store, _dir) = temp_store();
-      store.create(sample_item("/tmp/a.mp4")).unwrap();
-      store.create(sample_item("/tmp/b.mp4")).unwrap();
+      store.create(sample_record("/tmp/a.mp4")).unwrap();
+      store.create(sample_record("/tmp/b.mp4")).unwrap();
       assert_eq!(store.list().unwrap().len(), 2);
    }
 
    #[test]
    fn test_find_by_path_found() {
       let (store, _dir) = temp_store();
-      store.create(sample_item("/tmp/file.mp4")).unwrap();
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
       let result = store.find_by_path("/tmp/file.mp4").unwrap();
       assert_eq!(result.unwrap().path, "/tmp/file.mp4");
    }
@@ -190,31 +192,32 @@ mod tests {
    #[test]
    fn test_create_success() {
       let (store, _dir) = temp_store();
-      let item = store.create(sample_item("/tmp/file.mp4")).unwrap();
+      let item = store.create(sample_record("/tmp/file.mp4")).unwrap();
       assert_eq!(item.path, "/tmp/file.mp4");
    }
 
    #[test]
    fn test_create_persists_to_disk() {
       let (store, dir) = temp_store();
-      store.create(sample_item("/tmp/file.mp4")).unwrap();
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
       assert!(dir.path().join("downloads.json").exists());
    }
 
    #[test]
    fn test_create_duplicate_returns_error() {
       let (store, _dir) = temp_store();
-      store.create(sample_item("/tmp/file.mp4")).unwrap();
-      let result = store.create(sample_item("/tmp/file.mp4"));
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
+      let result = store.create(sample_record("/tmp/file.mp4"));
       assert!(result.is_err());
    }
 
    #[test]
    fn test_update_persists_to_disk() {
       let (store, dir) = temp_store();
-      let item = store.create(sample_item("/tmp/file.mp4")).unwrap();
-      let updated = DownloadItem {
-         progress: 50.0,
+      let item = store.create(sample_record("/tmp/file.mp4")).unwrap();
+      let updated = DownloadRecord {
+         received_bytes: 500,
+         total_bytes: Some(1000),
          status: DownloadStatus::InProgress,
          ..item
       };
@@ -223,14 +226,15 @@ mod tests {
       let reloaded = DownloadStore::new(dir.path().join("downloads.json"));
       reloaded.load().unwrap();
       let found = reloaded.find_by_path("/tmp/file.mp4").unwrap().unwrap();
-      assert_eq!(found.progress, 50.0);
+      assert_eq!(found.received_bytes, 500);
+      assert_eq!(found.total_bytes, Some(1000));
    }
 
    #[test]
    fn test_update_no_op_on_unknown_path() {
       let (store, _dir) = temp_store();
-      store.create(sample_item("/tmp/file.mp4")).unwrap();
-      let unknown = sample_item("/tmp/unknown.mp4");
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
+      let unknown = sample_record("/tmp/unknown.mp4");
       assert!(store.update(unknown).is_ok());
       assert_eq!(store.list().unwrap().len(), 1);
    }
@@ -238,28 +242,29 @@ mod tests {
    #[test]
    fn test_update_no_persist_does_not_write_disk() {
       let (store, dir) = temp_store();
-      let item = store.create(sample_item("/tmp/file.mp4")).unwrap();
-      let updated = DownloadItem {
-         progress: 75.0,
+      let item = store.create(sample_record("/tmp/file.mp4")).unwrap();
+      let updated = DownloadRecord {
+         received_bytes: 750,
+         total_bytes: Some(1000),
          ..item
       };
       store.update_no_persist(updated).unwrap();
 
       // In-memory reflects the change.
       let in_memory = store.find_by_path("/tmp/file.mp4").unwrap().unwrap();
-      assert_eq!(in_memory.progress, 75.0);
+      assert_eq!(in_memory.received_bytes, 750);
 
       // Disk still has the original value.
       let reloaded = DownloadStore::new(dir.path().join("downloads.json"));
       reloaded.load().unwrap();
       let on_disk = reloaded.find_by_path("/tmp/file.mp4").unwrap().unwrap();
-      assert_eq!(on_disk.progress, 0.0);
+      assert_eq!(on_disk.received_bytes, 0);
    }
 
    #[test]
    fn test_delete_removes_item_and_persists() {
       let (store, dir) = temp_store();
-      store.create(sample_item("/tmp/file.mp4")).unwrap();
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
       store.delete("/tmp/file.mp4").unwrap();
 
       assert!(store.list().unwrap().is_empty());
@@ -286,7 +291,7 @@ mod tests {
    fn test_load_from_valid_json() {
       let dir = TempDir::new().unwrap();
       let path = dir.path().join("downloads.json");
-      let items = vec![sample_item("/tmp/file.mp4")];
+      let items = vec![sample_record("/tmp/file.mp4")];
       fs::write(&path, serde_json::to_vec(&items).unwrap()).unwrap();
 
       let store = DownloadStore::new(path);
@@ -308,7 +313,7 @@ mod tests {
    fn test_save_creates_parent_directory() {
       let dir = TempDir::new().unwrap();
       let store = DownloadStore::new(dir.path().join("nested/dir/downloads.json"));
-      store.create(sample_item("/tmp/file.mp4")).unwrap();
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
       assert!(dir.path().join("nested/dir/downloads.json").exists());
    }
 }

--- a/guest-js/actions.ts
+++ b/guest-js/actions.ts
@@ -197,7 +197,9 @@ export function attachDownload<S extends DownloadStatus>(state: DownloadState<S>
    const download = {
       url: state.url,
       path: state.path,
-      progress: state.progress,
+      receivedBytes: state.receivedBytes ?? 0,
+      totalBytes: state.totalBytes ?? null,
+      progress: state.progress ?? 0,
       status: state.status,
    } satisfies DownloadState<S>;
 

--- a/guest-js/index.test.ts
+++ b/guest-js/index.test.ts
@@ -30,6 +30,8 @@ let lastCmd = '',
 const IDLE_STATE = {
    url: 'https://example.com/file.zip',
    path: '/tmp/file.zip',
+   receivedBytes: 0,
+   totalBytes: null,
    progress: 0,
    status: DownloadStatus.Idle,
 };
@@ -37,6 +39,8 @@ const IDLE_STATE = {
 const IN_PROGRESS_STATE = {
    url: 'https://example.com/file.zip',
    path: '/tmp/file.zip',
+   receivedBytes: 42,
+   totalBytes: 100,
    progress: 42,
    status: DownloadStatus.InProgress,
 };
@@ -44,6 +48,8 @@ const IN_PROGRESS_STATE = {
 const PAUSED_STATE = {
    url: 'https://example.com/file.zip',
    path: '/tmp/file.zip',
+   receivedBytes: 42,
+   totalBytes: 100,
    progress: 42,
    status: DownloadStatus.Paused,
 };
@@ -71,6 +77,8 @@ beforeEach(() => {
          return {
             url: '',
             path,
+            receivedBytes: 0,
+            totalBytes: null,
             progress: 0,
             status: DownloadStatus.Pending,
          };
@@ -243,6 +251,8 @@ describe('state machine — action availability', () => {
       const download = attachDownload({
          url: '',
          path: '/tmp/file.zip',
+         receivedBytes: 0,
+         totalBytes: null,
          progress: 0,
          status: DownloadStatus.Pending,
       });
@@ -330,6 +340,8 @@ describe('state machine — action availability', () => {
 
       expect(download.url).toBe('https://example.com/file.zip');
       expect(download.path).toBe('/tmp/file.zip');
+      expect(download.receivedBytes).toBe(42);
+      expect(download.totalBytes).toBe(100);
       expect(download.progress).toBe(42);
       expect(download.status).toBe(DownloadStatus.InProgress);
    });

--- a/guest-js/mocks.test.ts
+++ b/guest-js/mocks.test.ts
@@ -58,6 +58,28 @@ async function invokeAction(action: Exclude<DownloadAction, DownloadAction.Liste
 }
 
 describe('mockDownloadPlugin', () => {
+   it('normalizes completed progress while preserving byte counts', () => {
+      const state = createMockDownloadState(DownloadStatus.Completed, {
+         receivedBytes: 30,
+         totalBytes: 100,
+      });
+
+      expect(state).toEqual(expect.objectContaining({
+         receivedBytes: 30,
+         totalBytes: 100,
+         progress: 100,
+      }));
+   });
+
+   it('clamps derived progress to 100 percent', () => {
+      const { progress } = createMockDownloadState(DownloadStatus.InProgress, {
+         receivedBytes: 150,
+         totalBytes: 100,
+      });
+
+      expect(progress).toBe(100);
+   });
+
    it('seeds downloads for list and records invocations', async () => {
       const controller = mockDownloadPlugin({
          downloads: [
@@ -98,6 +120,8 @@ describe('mockDownloadPlugin', () => {
       expect(controller.getDownload('/tmp/new.zip')).toEqual({
          url: 'https://example.com/new.zip',
          path: '/tmp/new.zip',
+         receivedBytes: 0,
+         totalBytes: null,
          progress: 0,
          status: DownloadStatus.Idle,
       });
@@ -124,13 +148,15 @@ describe('mockDownloadPlugin', () => {
 
       await controller.emitChange(createMockDownloadState(DownloadStatus.InProgress, {
          path: '/tmp/listener.zip',
-         progress: 42,
+         receivedBytes: 42,
+         totalBytes: 100,
       }));
 
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenCalledWith(expect.objectContaining({
          path: '/tmp/listener.zip',
-         progress: 42,
+         receivedBytes: 42,
+         totalBytes: 100,
          status: DownloadStatus.InProgress,
       }));
       expect(hasAction(listener.mock.calls[0][0], DownloadAction.Pause)).toBe(true);
@@ -159,7 +185,8 @@ describe('mockDownloadPlugin', () => {
 
       await firstController.emitChange(createMockDownloadState(DownloadStatus.InProgress, {
          path: '/tmp/first-listener.zip',
-         progress: 10,
+         receivedBytes: 10,
+         totalBytes: 100,
       }));
 
       expect(firstListener).toHaveBeenCalledTimes(1);
@@ -186,7 +213,8 @@ describe('mockDownloadPlugin', () => {
 
       await secondController.emitChange(createMockDownloadState(DownloadStatus.InProgress, {
          path: '/tmp/second-listener.zip',
-         progress: 20,
+         receivedBytes: 20,
+         totalBytes: 100,
       }));
 
       expect(secondListener).toHaveBeenCalledTimes(1);

--- a/guest-js/mocks.ts
+++ b/guest-js/mocks.ts
@@ -121,6 +121,8 @@ function createPendingDownload(path: string): DownloadState<DownloadStatus.Pendi
    return {
       url: '',
       path,
+      receivedBytes: 0,
+      totalBytes: null,
       progress: 0,
       status: DownloadStatus.Pending,
    };
@@ -202,6 +204,10 @@ function createTransitionDownload(
 /**
  * Creates a mock download state object for tests.
  *
+ * Unless `progress` is explicitly overridden, progress is derived from
+ * `receivedBytes` and `totalBytes`. Unknown-size downloads use
+ * `totalBytes: null`, and completed downloads default to `progress: 100`.
+ *
  * @param status - The download status to assign to the mock state.
  * @param overrides - Optional properties to override on the generated state.
  * @returns A mock download state with defaults for unspecified fields.
@@ -210,10 +216,26 @@ export function createMockDownloadState(
    status: DownloadStatus,
    overrides: Partial<DownloadState<DownloadStatus>> = {}
 ): DownloadState<DownloadStatus> {
+   const receivedBytes = overrides.receivedBytes ?? 0;
+
+   const totalBytes = overrides.totalBytes ?? null;
+
+   let computedProgress = 0;
+
+   if (overrides.progress !== undefined) {
+      computedProgress = overrides.progress;
+   } else if (status === DownloadStatus.Completed) {
+      computedProgress = 100;
+   } else if (totalBytes !== null && totalBytes > 0) {
+      computedProgress = Math.min((receivedBytes / totalBytes) * 100, 100);
+   }
+
    return {
       url: overrides.url ?? DEFAULT_URL,
       path: overrides.path ?? '/tmp/file.zip',
-      progress: overrides.progress ?? 0,
+      receivedBytes,
+      totalBytes,
+      progress: computedProgress,
       status,
    };
 }
@@ -392,9 +414,6 @@ export function mockDownloadPlugin(
 
       /**
        * Emits a mocked desktop download change event.
-       *
-       * When simulating a `Completed` download, callers must provide `progress: 100`
-       * themselves because the mock does not normalize progress for terminal states.
        */
       async emitChange(download: DownloadState<DownloadStatus>): Promise<void> {
          setDownloadForPath(downloadsByPath, download);

--- a/guest-js/types.ts
+++ b/guest-js/types.ts
@@ -51,6 +51,8 @@ export enum DownloadAction {
 export interface DownloadState<S extends DownloadStatus> {
    url: string;
    path: string;
+   receivedBytes: number;
+   totalBytes: number | null;
    progress: number;
    status: S;
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -25,6 +25,11 @@ mod mobile_types {
    pub struct DownloadItem {
       pub url: String,
       pub path: String,
+      #[serde(default)]
+      pub received_bytes: u64,
+      #[serde(default)]
+      pub total_bytes: Option<u64>,
+      #[serde(default)]
       pub progress: f64,
       pub status: DownloadStatus,
    }


### PR DESCRIPTION
The Rust part of #46 

To start, this _adds_ two fields, bytesReceived and totalBytes. They are read back from the store, and the progress is then computed from them. All those fields are sent to the front-end, which can display the progress percent, but also inspect the number of bytes received and expected.

r? @velocitysystems 