### PR TITLE
feat: add desktop network policy for downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "connectivity"
 version = "0.1.0"
-source = "git+https://github.com/silvermine/tauri-plugin-connectivity?rev=e14c43d85e153d6e867277e8e3759570f83ba503#e14c43d85e153d6e867277e8e3759570f83ba503"
+source = "git+https://github.com/silvermine/tauri-plugin-connectivity?rev=3f127708860d9cd1463e4c94628ac67db520c006#3f127708860d9cd1463e4c94628ac67db520c006"
 dependencies = [
  "block2",
  "dispatch2",
@@ -3333,7 +3333,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4599,7 +4599,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4999,7 +4999,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +288,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -365,6 +498,28 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "connectivity"
+version = "0.1.0"
+source = "git+https://github.com/silvermine/tauri-plugin-connectivity#e14c43d85e153d6e867277e8e3759570f83ba503"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "serde",
+ "tracing",
+ "windows 0.62.2",
+ "zbus",
 ]
 
 [[package]]
@@ -628,11 +783,13 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -674,6 +831,7 @@ dependencies = [
 name = "download-manager"
 version = "0.1.0"
 dependencies = [
+ "connectivity",
  "futures",
  "reqwest 0.13.1",
  "reqwest-middleware",
@@ -754,6 +912,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +963,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -926,6 +1131,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2264,6 +2482,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,6 +2515,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2464,6 +2698,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2738,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3421,6 +3680,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,7 +3941,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3743,7 +4012,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3861,7 +4130,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3887,7 +4156,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4323,6 +4592,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4669,7 +4949,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -4693,7 +4973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4749,11 +5029,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -4763,6 +5055,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4799,7 +5100,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -4844,6 +5156,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4993,6 +5315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5161,6 +5492,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5244,7 +5584,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5292,6 +5632,67 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
 ]
 
 [[package]]
@@ -5379,3 +5780,43 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.114",
+ "winnow 1.0.4",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "connectivity"
 version = "0.1.0"
-source = "git+https://github.com/silvermine/tauri-plugin-connectivity#e14c43d85e153d6e867277e8e3759570f83ba503"
+source = "git+https://github.com/silvermine/tauri-plugin-connectivity?rev=e14c43d85e153d6e867277e8e3759570f83ba503#e14c43d85e153d6e867277e8e3759570f83ba503"
 dependencies = [
  "block2",
  "dispatch2",

--- a/README.md
+++ b/README.md
@@ -186,6 +186,29 @@ async function manageDownload() {
 }
 ```
 
+On desktop, a download can be restricted to unmetered, unconstrained networks when it
+is created:
+
+```ts
+const download = await get('/path/to/large-file.zip');
+
+if (download.status === DownloadStatus.Pending) {
+   const { download: created } = await download.create(
+      'https://example.com/large-file.zip',
+      { allowMetered: false }
+   );
+
+   await created.start();
+}
+```
+
+`allowMetered` defaults to `true`. When it is `false`, both `start()` and `resume()`
+reject if there is no active connection, connectivity cannot be determined, or the
+current connection is reported as metered or constrained. The stored download remains
+idle or paused so the action can be retried later. A connection change does not stop a
+download that is already in progress. Android and iOS currently accept this option but
+do not enforce it.
+
 #### Listen for progress notifications
 
 Listeners can be attached to downloads in any status, including `Pending`.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ idle or paused so the action can be retried later. A connection change does not 
 download that is already in progress. Android and iOS currently accept this option but
 do not enforce it.
 
+The network policy is fixed when the download is first created. Every download state
+exposes its resolved policy through `download.options.allowMetered`. Calling `create()`
+again for an existing path returns the existing record without changing its URL or
+options.
+
 #### Listen for progress notifications
 
 Listeners can be attached to downloads in any status, including `Pending`.

--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 rust-version = "1.94.0"
 
 [dependencies]
+connectivity = { git = "https://github.com/silvermine/tauri-plugin-connectivity" }
 futures = "0.3.31"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 rust-version = "1.94.0"
 
 [dependencies]
-connectivity = { git = "https://github.com/silvermine/tauri-plugin-connectivity" }
+connectivity = { version = "0.1.0", git = "https://github.com/silvermine/tauri-plugin-connectivity", rev = "e14c43d85e153d6e867277e8e3759570f83ba503" }
 futures = "0.3.31"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 rust-version = "1.94.0"
 
 [dependencies]
-connectivity = { version = "0.1.0", git = "https://github.com/silvermine/tauri-plugin-connectivity", rev = "e14c43d85e153d6e867277e8e3759570f83ba503" }
+connectivity = { version = "0.1.0", git = "https://github.com/silvermine/tauri-plugin-connectivity", rev = "3f127708860d9cd1463e4c94628ac67db520c006" }
 futures = "0.3.31"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/download-manager/src/downloader.rs
+++ b/crates/download-manager/src/downloader.rs
@@ -287,6 +287,7 @@ mod tests {
       let item = DownloadRecord {
          url: url.to_string(),
          path: dest_path.to_string(),
+         options: CreateOptions::default(),
          received_bytes: 0,
          total_bytes: None,
          status: DownloadStatus::InProgress,

--- a/crates/download-manager/src/error.rs
+++ b/crates/download-manager/src/error.rs
@@ -32,7 +32,10 @@ pub enum Error {
    NetworkRestricted,
 
    #[error("Connectivity Error: {0}")]
-   Connectivity(#[from] connectivity::Error),
+   Connectivity(String),
+
+   #[error("Internal Error: {0}")]
+   Internal(String),
 
    #[error(transparent)]
    Io(#[from] std::io::Error),
@@ -77,6 +80,14 @@ mod tests {
       assert_eq!(
          Error::NetworkRestricted.to_string(),
          "Network restricted: metered or constrained connections are not allowed"
+      );
+      assert_eq!(
+         Error::Connectivity("backend unavailable".to_string()).to_string(),
+         "Connectivity Error: backend unavailable"
+      );
+      assert_eq!(
+         Error::Internal("Connectivity worker failed".to_string()).to_string(),
+         "Internal Error: Connectivity worker failed"
       );
    }
 

--- a/crates/download-manager/src/error.rs
+++ b/crates/download-manager/src/error.rs
@@ -25,6 +25,15 @@ pub enum Error {
    #[error("Path Error: {0}")]
    Path(String),
 
+   #[error("Network unavailable: no active connection")]
+   NetworkUnavailable,
+
+   #[error("Network restricted: metered or constrained connections are not allowed")]
+   NetworkRestricted,
+
+   #[error("Connectivity Error: {0}")]
+   Connectivity(#[from] connectivity::Error),
+
    #[error(transparent)]
    Io(#[from] std::io::Error),
 }
@@ -60,6 +69,14 @@ mod tests {
       assert_eq!(
          Error::Http("timeout".to_string()).to_string(),
          "HTTP Error: timeout"
+      );
+      assert_eq!(
+         Error::NetworkUnavailable.to_string(),
+         "Network unavailable: no active connection"
+      );
+      assert_eq!(
+         Error::NetworkRestricted.to_string(),
+         "Network restricted: metered or constrained connections are not allowed"
       );
    }
 

--- a/crates/download-manager/src/lib.rs
+++ b/crates/download-manager/src/lib.rs
@@ -7,4 +7,4 @@ mod validate;
 
 pub use error::{Error, Result};
 pub use manager::{DownloadManager, OnChanged};
-pub use models::{DownloadActionResponse, DownloadItem, DownloadStatus};
+pub use models::{CreateOptions, DownloadActionResponse, DownloadItem, DownloadStatus};

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -147,6 +147,8 @@ impl DownloadManager {
    /// Creates a download operation with network policy options.
    ///
    /// Existing records are returned unchanged, including their original options.
+   /// Options are fixed on initial creation and cannot be updated by calling this
+   /// method again.
    ///
    /// # Arguments
    /// - `path` - The download path.
@@ -542,6 +544,23 @@ mod tests {
       let item = manager.get("/tmp/file.mp4").unwrap();
       assert_eq!(item.status, DownloadStatus::Idle);
       assert_eq!(item.url, VALID_URL);
+      assert!(item.options.allow_metered);
+   }
+
+   #[test]
+   fn test_list_returns_persisted_options() {
+      let (manager, _dir, _events) = make_manager();
+      let options = CreateOptions {
+         allow_metered: false,
+      };
+      manager
+         .create_with_options("/tmp/file.mp4", VALID_URL, options)
+         .unwrap();
+
+      let items = manager.list().unwrap();
+
+      assert_eq!(items.len(), 1);
+      assert_eq!(items[0].options, options);
    }
 
    #[test]
@@ -624,10 +643,11 @@ mod tests {
          .create_with_options(path, VALID_URL, restricted)
          .unwrap();
 
-      manager.create(path, VALID_URL).unwrap();
+      let response = manager.create(path, VALID_URL).unwrap();
 
       let stored = manager.store.find_by_path(path).unwrap().unwrap();
       assert_eq!(stored.options, restricted);
+      assert_eq!(response.download.options, restricted);
    }
 
    #[test]

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -480,18 +480,25 @@ mod tests {
       panic!("connectivity should not be checked")
    }
 
-   async fn make_mock_download(dir: &TempDir) -> (MockServer, String, String) {
+   async fn make_mock_download_expecting(
+      dir: &TempDir,
+      expected_requests: u64,
+   ) -> (MockServer, String, String) {
       let server = MockServer::start().await;
       Mock::given(method("GET"))
          .and(wm_path("/file.mp4"))
          .respond_with(ResponseTemplate::new(200).set_body_bytes(MOCK_BODY.to_vec()))
-         .expect(1)
+         .expect(expected_requests)
          .mount(&server)
          .await;
 
       let path = dir.path().join("file.mp4").to_string_lossy().into_owned();
       let url = format!("{}/file.mp4", server.uri());
       (server, path, url)
+   }
+
+   async fn make_mock_download(dir: &TempDir) -> (MockServer, String, String) {
+      make_mock_download_expecting(dir, 1).await
    }
 
    async fn wait_for_download(manager: &DownloadManager, path: &str) {
@@ -794,15 +801,7 @@ mod tests {
          provider_release_check.wait();
          Ok(connected_status(false, false))
       });
-      let server = MockServer::start().await;
-      Mock::given(method("GET"))
-         .and(wm_path("/file.mp4"))
-         .respond_with(ResponseTemplate::new(200).set_body_bytes(MOCK_BODY.to_vec()))
-         .expect(0)
-         .mount(&server)
-         .await;
-      let path = dir.path().join("file.mp4").to_string_lossy().into_owned();
-      let url = format!("{}/file.mp4", server.uri());
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       manager
          .create_with_options(
             &path,
@@ -835,13 +834,12 @@ mod tests {
 
    #[tokio::test]
    async fn test_start_restricted_rejects_metered_connection_without_state_change() {
-      let (manager, _dir, events) =
-         make_manager_with_provider(|| Ok(connected_status(true, false)));
-      let path = "/tmp/file.mp4";
+      let (manager, dir, events) = make_manager_with_provider(|| Ok(connected_status(true, false)));
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       manager
          .create_with_options(
-            path,
-            VALID_URL,
+            &path,
+            &url,
             CreateOptions {
                allow_metered: false,
             },
@@ -850,25 +848,26 @@ mod tests {
       clear_events(&events);
 
       assert!(matches!(
-         manager.start(path).await,
+         manager.start(&path).await,
          Err(Error::NetworkRestricted)
       ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
       assert!(event_log(&events).is_empty());
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_start_restricted_rejects_constrained_connection() {
-      let (manager, _dir, _events) =
+      let (manager, dir, _events) =
          make_manager_with_provider(|| Ok(connected_status(false, true)));
-      let path = "/tmp/file.mp4";
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       manager
          .create_with_options(
-            path,
-            VALID_URL,
+            &path,
+            &url,
             CreateOptions {
                allow_metered: false,
             },
@@ -876,23 +875,24 @@ mod tests {
          .unwrap();
 
       assert!(matches!(
-         manager.start(path).await,
+         manager.start(&path).await,
          Err(Error::NetworkRestricted)
       ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_start_restricted_rejects_disconnected_network() {
-      let (manager, _dir, _events) = make_manager();
-      let path = "/tmp/file.mp4";
+      let (manager, dir, _events) = make_manager();
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       manager
          .create_with_options(
-            path,
-            VALID_URL,
+            &path,
+            &url,
             CreateOptions {
                allow_metered: false,
             },
@@ -900,28 +900,29 @@ mod tests {
          .unwrap();
 
       assert!(matches!(
-         manager.start(path).await,
+         manager.start(&path).await,
          Err(Error::NetworkUnavailable)
       ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_start_restricted_propagates_connectivity_error() {
-      let (manager, _dir, _events) = make_manager_with_provider(|| {
+      let (manager, dir, _events) = make_manager_with_provider(|| {
          Err(connectivity::Error::DetectionFailed {
             message: "backend unavailable".to_string(),
             code: None,
          })
       });
-      let path = "/tmp/file.mp4";
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       manager
          .create_with_options(
-            path,
-            VALID_URL,
+            &path,
+            &url,
             CreateOptions {
                allow_metered: false,
             },
@@ -929,49 +930,63 @@ mod tests {
          .unwrap();
 
       assert!(matches!(
-         manager.start(path).await,
+         manager.start(&path).await,
          Err(Error::Connectivity(_))
       ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_start_restricted_fails_closed_when_connectivity_worker_panics() {
-      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
-      let path = "/tmp/file.mp4";
+      let (manager, dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       manager
          .create_with_options(
-            path,
-            VALID_URL,
+            &path,
+            &url,
             CreateOptions {
                allow_metered: false,
             },
          )
          .unwrap();
 
-      assert!(matches!(manager.start(path).await, Err(Error::Internal(_))));
+      assert!(matches!(
+         manager.start(&path).await,
+         Err(Error::Internal(_))
+      ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_start_from_non_idle_skips_connectivity_check() {
-      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
-      seed_with_options(
+      let (manager, dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
+      seed_with_url_and_options(
          &manager,
-         "/tmp/file.mp4",
+         &path,
+         &url,
          DownloadStatus::InProgress,
          CreateOptions {
             allow_metered: false,
          },
       );
 
-      manager.start("/tmp/file.mp4").await.unwrap();
+      let response = manager.start(&path).await.unwrap();
+
+      assert_eq!(response.download.status, DownloadStatus::InProgress);
+      assert_eq!(
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
+         DownloadStatus::InProgress
+      );
+      server.verify().await;
    }
 
    // ---------- resume ----------
@@ -993,17 +1008,26 @@ mod tests {
 
    #[tokio::test]
    async fn test_resume_from_non_paused_does_not_change_state() {
-      let (manager, _dir, _events) = make_manager();
-      let path = "/tmp/file.mp4";
-      seed(&manager, path, DownloadStatus::Idle);
+      let (manager, dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
+      seed_with_url_and_options(
+         &manager,
+         &path,
+         &url,
+         DownloadStatus::Idle,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
 
-      let response = manager.resume(path).await.unwrap();
+      let response = manager.resume(&path).await.unwrap();
       assert_eq!(response.download.status, DownloadStatus::Idle);
       assert_eq!(response.expected_status, DownloadStatus::InProgress);
       assert!(!response.is_expected_status);
 
-      let stored = manager.store.find_by_path(path).unwrap().unwrap();
+      let stored = manager.store.find_by_path(&path).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::Idle);
+      server.verify().await;
    }
 
    #[tokio::test]
@@ -1079,12 +1103,12 @@ mod tests {
 
    #[tokio::test]
    async fn test_resume_restricted_rejects_metered_connection_without_state_change() {
-      let (manager, _dir, events) =
-         make_manager_with_provider(|| Ok(connected_status(true, false)));
-      let path = "/tmp/file.mp4";
-      seed_with_options(
+      let (manager, dir, events) = make_manager_with_provider(|| Ok(connected_status(true, false)));
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
+      seed_with_url_and_options(
          &manager,
-         path,
+         &path,
+         &url,
          DownloadStatus::Paused,
          CreateOptions {
             allow_metered: false,
@@ -1092,23 +1116,25 @@ mod tests {
       );
 
       assert!(matches!(
-         manager.resume(path).await,
+         manager.resume(&path).await,
          Err(Error::NetworkRestricted)
       ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Paused
       );
       assert!(event_log(&events).is_empty());
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_resume_restricted_fails_closed_when_connectivity_worker_panics() {
-      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
-      let path = "/tmp/file.mp4";
-      seed_with_options(
+      let (manager, dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
+      seed_with_url_and_options(
          &manager,
-         path,
+         &path,
+         &url,
          DownloadStatus::Paused,
          CreateOptions {
             allow_metered: false,
@@ -1116,13 +1142,14 @@ mod tests {
       );
 
       assert!(matches!(
-         manager.resume(path).await,
+         manager.resume(&path).await,
          Err(Error::Internal(_))
       ));
       assert_eq!(
-         manager.store.find_by_path(path).unwrap().unwrap().status,
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Paused
       );
+      server.verify().await;
    }
 
    // ---------- pause ----------

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -190,7 +190,7 @@ impl DownloadManager {
    ///
    /// # Returns
    /// The download operation.
-   pub fn start(&self, path: &str) -> crate::Result<DownloadActionResponse> {
+   pub async fn start(&self, path: &str) -> crate::Result<DownloadActionResponse> {
       validate::path(path)?;
 
       let item = self
@@ -200,7 +200,7 @@ impl DownloadManager {
       match item.status {
          // Allow download to be started when idle.
          DownloadStatus::Idle => {
-            self.ensure_network_allowed(&item)?;
+            self.ensure_network_allowed(&item).await?;
             self.spawn_download(item, "failed to start")
          }
 
@@ -220,7 +220,7 @@ impl DownloadManager {
    ///
    /// # Returns
    /// The download operation.
-   pub fn resume(&self, path: &str) -> crate::Result<DownloadActionResponse> {
+   pub async fn resume(&self, path: &str) -> crate::Result<DownloadActionResponse> {
       validate::path(path)?;
 
       let item = self
@@ -230,7 +230,7 @@ impl DownloadManager {
       match item.status {
          // Allow download to be resumed when paused.
          DownloadStatus::Paused => {
-            self.ensure_network_allowed(&item)?;
+            self.ensure_network_allowed(&item).await?;
             self.spawn_download(item, "failed to resume")
          }
 
@@ -275,12 +275,17 @@ impl DownloadManager {
       Ok(DownloadActionResponse::new(public_item))
    }
 
-   fn ensure_network_allowed(&self, item: &DownloadRecord) -> crate::Result<()> {
+   async fn ensure_network_allowed(&self, item: &DownloadRecord) -> crate::Result<()> {
       if item.options.allow_metered {
          return Ok(());
       }
 
-      let status = (self.connection_status)()?;
+      let status = tokio::task::spawn_blocking(self.connection_status)
+         .await
+         .map_err(|error| connectivity::Error::DetectionFailed {
+            message: format!("connection status worker failed: {error}"),
+            code: None,
+         })??;
 
       if !status.connected {
          return Err(Error::NetworkUnavailable);
@@ -599,28 +604,28 @@ mod tests {
 
    // ---------- start ----------
 
-   #[test]
-   fn test_start_unknown_path_returns_not_found() {
+   #[tokio::test]
+   async fn test_start_unknown_path_returns_not_found() {
       let (manager, _dir, _events) = make_manager();
       assert!(matches!(
-         manager.start("/tmp/unknown.mp4"),
+         manager.start("/tmp/unknown.mp4").await,
          Err(Error::NotFound(_))
       ));
    }
 
-   #[test]
-   fn test_start_rejects_invalid_path() {
+   #[tokio::test]
+   async fn test_start_rejects_invalid_path() {
       let (manager, _dir, _events) = make_manager();
-      assert!(manager.start("").is_err());
+      assert!(manager.start("").await.is_err());
    }
 
-   #[test]
-   fn test_start_from_non_idle_does_not_change_state() {
+   #[tokio::test]
+   async fn test_start_from_non_idle_does_not_change_state() {
       let (manager, _dir, _events) = make_manager();
       let path = "/tmp/file.mp4";
       seed(&manager, path, DownloadStatus::InProgress);
 
-      let response = manager.start(path).unwrap();
+      let response = manager.start(path).await.unwrap();
       assert_eq!(response.download.status, DownloadStatus::InProgress);
       assert_eq!(response.expected_status, DownloadStatus::InProgress);
       assert!(response.is_expected_status);
@@ -634,7 +639,7 @@ mod tests {
       let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
       manager.create("/tmp/file.mp4", LOCAL_URL).unwrap();
 
-      let response = manager.start("/tmp/file.mp4").unwrap();
+      let response = manager.start("/tmp/file.mp4").await.unwrap();
 
       assert_eq!(response.download.status, DownloadStatus::InProgress);
    }
@@ -653,13 +658,13 @@ mod tests {
          )
          .unwrap();
 
-      let response = manager.start("/tmp/file.mp4").unwrap();
+      let response = manager.start("/tmp/file.mp4").await.unwrap();
 
       assert_eq!(response.download.status, DownloadStatus::InProgress);
    }
 
-   #[test]
-   fn test_start_restricted_rejects_metered_connection_without_state_change() {
+   #[tokio::test]
+   async fn test_start_restricted_rejects_metered_connection_without_state_change() {
       let (manager, _dir, events) =
          make_manager_with_provider(|| Ok(connected_status(true, false)));
       let path = "/tmp/file.mp4";
@@ -674,7 +679,10 @@ mod tests {
          .unwrap();
       clear_events(&events);
 
-      assert!(matches!(manager.start(path), Err(Error::NetworkRestricted)));
+      assert!(matches!(
+         manager.start(path).await,
+         Err(Error::NetworkRestricted)
+      ));
       assert_eq!(
          manager.store.find_by_path(path).unwrap().unwrap().status,
          DownloadStatus::Idle
@@ -682,8 +690,8 @@ mod tests {
       assert!(event_log(&events).is_empty());
    }
 
-   #[test]
-   fn test_start_restricted_rejects_constrained_connection() {
+   #[tokio::test]
+   async fn test_start_restricted_rejects_constrained_connection() {
       let (manager, _dir, _events) =
          make_manager_with_provider(|| Ok(connected_status(false, true)));
       let path = "/tmp/file.mp4";
@@ -697,15 +705,18 @@ mod tests {
          )
          .unwrap();
 
-      assert!(matches!(manager.start(path), Err(Error::NetworkRestricted)));
+      assert!(matches!(
+         manager.start(path).await,
+         Err(Error::NetworkRestricted)
+      ));
       assert_eq!(
          manager.store.find_by_path(path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
    }
 
-   #[test]
-   fn test_start_restricted_rejects_disconnected_network() {
+   #[tokio::test]
+   async fn test_start_restricted_rejects_disconnected_network() {
       let (manager, _dir, _events) = make_manager();
       let path = "/tmp/file.mp4";
       manager
@@ -719,7 +730,7 @@ mod tests {
          .unwrap();
 
       assert!(matches!(
-         manager.start(path),
+         manager.start(path).await,
          Err(Error::NetworkUnavailable)
       ));
       assert_eq!(
@@ -728,8 +739,8 @@ mod tests {
       );
    }
 
-   #[test]
-   fn test_start_restricted_propagates_connectivity_error() {
+   #[tokio::test]
+   async fn test_start_restricted_propagates_connectivity_error() {
       let (manager, _dir, _events) = make_manager_with_provider(|| {
          Err(connectivity::Error::DetectionFailed {
             message: "backend unavailable".to_string(),
@@ -747,15 +758,18 @@ mod tests {
          )
          .unwrap();
 
-      assert!(matches!(manager.start(path), Err(Error::Connectivity(_))));
+      assert!(matches!(
+         manager.start(path).await,
+         Err(Error::Connectivity(_))
+      ));
       assert_eq!(
          manager.store.find_by_path(path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
    }
 
-   #[test]
-   fn test_start_from_non_idle_skips_connectivity_check() {
+   #[tokio::test]
+   async fn test_start_from_non_idle_skips_connectivity_check() {
       let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
       seed_with_options(
          &manager,
@@ -766,33 +780,33 @@ mod tests {
          },
       );
 
-      manager.start("/tmp/file.mp4").unwrap();
+      manager.start("/tmp/file.mp4").await.unwrap();
    }
 
    // ---------- resume ----------
 
-   #[test]
-   fn test_resume_unknown_path_returns_not_found() {
+   #[tokio::test]
+   async fn test_resume_unknown_path_returns_not_found() {
       let (manager, _dir, _events) = make_manager();
       assert!(matches!(
-         manager.resume("/tmp/unknown.mp4"),
+         manager.resume("/tmp/unknown.mp4").await,
          Err(Error::NotFound(_))
       ));
    }
 
-   #[test]
-   fn test_resume_rejects_invalid_path() {
+   #[tokio::test]
+   async fn test_resume_rejects_invalid_path() {
       let (manager, _dir, _events) = make_manager();
-      assert!(manager.resume("").is_err());
+      assert!(manager.resume("").await.is_err());
    }
 
-   #[test]
-   fn test_resume_from_non_paused_does_not_change_state() {
+   #[tokio::test]
+   async fn test_resume_from_non_paused_does_not_change_state() {
       let (manager, _dir, _events) = make_manager();
       let path = "/tmp/file.mp4";
       seed(&manager, path, DownloadStatus::Idle);
 
-      let response = manager.resume(path).unwrap();
+      let response = manager.resume(path).await.unwrap();
       assert_eq!(response.download.status, DownloadStatus::Idle);
       assert_eq!(response.expected_status, DownloadStatus::InProgress);
       assert!(!response.is_expected_status);
@@ -801,8 +815,8 @@ mod tests {
       assert_eq!(stored.status, DownloadStatus::Idle);
    }
 
-   #[test]
-   fn test_resume_restricted_rejects_metered_connection_without_state_change() {
+   #[tokio::test]
+   async fn test_resume_restricted_rejects_metered_connection_without_state_change() {
       let (manager, _dir, events) =
          make_manager_with_provider(|| Ok(connected_status(true, false)));
       let path = "/tmp/file.mp4";
@@ -816,7 +830,7 @@ mod tests {
       );
 
       assert!(matches!(
-         manager.resume(path),
+         manager.resume(path).await,
          Err(Error::NetworkRestricted)
       ));
       assert_eq!(

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -8,11 +8,12 @@ use tracing::{debug, error, info, warn};
 use crate::Error;
 use crate::downloader;
 use crate::models::*;
-use crate::store::DownloadStore;
+use crate::store::{DownloadStore, UpdateIfStatusResult};
 use crate::validate;
 
 type HttpClient = reqwest_middleware::ClientWithMiddleware;
-type ConnectionStatusProvider = fn() -> connectivity::Result<connectivity::ConnectionStatus>;
+type ConnectionStatusProvider =
+   Arc<dyn Fn() -> connectivity::Result<connectivity::ConnectionStatus> + Send + Sync>;
 
 pub(crate) static DOWNLOAD_SUFFIX: &str = ".download";
 
@@ -42,7 +43,11 @@ impl DownloadManager {
          let _ = connectivity::connection_status();
       }
 
-      Self::with_connection_status_provider(data_dir, on_changed, connectivity::connection_status)
+      Self::with_connection_status_provider(
+         data_dir,
+         on_changed,
+         Arc::new(connectivity::connection_status),
+      )
    }
 
    fn with_connection_status_provider(
@@ -210,7 +215,7 @@ impl DownloadManager {
          // Allow download to be started when idle.
          DownloadStatus::Idle => {
             self.ensure_network_allowed(&item).await?;
-            self.spawn_download(item, "failed to start")
+            self.spawn_download(item, DownloadStatus::Idle, "failed to start")
          }
 
          // Return current state if in any other state.
@@ -240,7 +245,7 @@ impl DownloadManager {
          // Allow download to be resumed when paused.
          DownloadStatus::Paused => {
             self.ensure_network_allowed(&item).await?;
-            self.spawn_download(item, "failed to resume")
+            self.spawn_download(item, DownloadStatus::Paused, "failed to resume")
          }
 
          // Return current state if in any other state.
@@ -254,10 +259,23 @@ impl DownloadManager {
    fn spawn_download(
       &self,
       item: DownloadRecord,
+      expected_status: DownloadStatus,
       err_msg: &'static str,
    ) -> crate::Result<DownloadActionResponse> {
-      let item_in_progress = item.with_status(DownloadStatus::InProgress);
-      self.store.update(item_in_progress.clone())?;
+      let item_in_progress = match self.store.update_if_status(
+         &item.path,
+         expected_status,
+         DownloadStatus::InProgress,
+      )? {
+         UpdateIfStatusResult::Updated(item) => item,
+         UpdateIfStatusResult::Unchanged(current) => {
+            return Ok(DownloadActionResponse::with_expected_status(
+               current.to_item(),
+               DownloadStatus::InProgress,
+            ));
+         }
+         UpdateIfStatusResult::NotFound => return Err(Error::NotFound(item.path)),
+      };
 
       let manager = self.clone();
       let path = item.path.clone();
@@ -289,7 +307,8 @@ impl DownloadManager {
          return Ok(());
       }
 
-      let status = tokio::task::spawn_blocking(self.connection_status)
+      let connection_status = self.connection_status.clone();
+      let status = tokio::task::spawn_blocking(move || connection_status())
          .await
          .map_err(|error| connectivity::Error::DetectionFailed {
             message: format!("connection status worker failed: {error}"),
@@ -418,7 +437,7 @@ fn filename(path: &str) -> &str {
 mod tests {
    use super::*;
    use connectivity::{ConnectionStatus, ConnectionType};
-   use std::sync::Mutex;
+   use std::sync::{Barrier, Mutex};
    use std::time::Duration;
    use tempfile::TempDir;
    use wiremock::matchers::{method, path as wm_path};
@@ -434,7 +453,7 @@ mod tests {
    }
 
    fn make_manager_with_provider(
-      connection_status: ConnectionStatusProvider,
+      connection_status: impl Fn() -> connectivity::Result<ConnectionStatus> + Send + Sync + 'static,
    ) -> (DownloadManager, TempDir, EventLog) {
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
@@ -445,7 +464,7 @@ mod tests {
       let manager = DownloadManager::with_connection_status_provider(
          dir.path().to_path_buf(),
          on_changed,
-         connection_status,
+         Arc::new(connection_status),
       );
       (manager, dir, events)
    }
@@ -739,6 +758,84 @@ mod tests {
    }
 
    #[tokio::test]
+   async fn test_start_restricted_concurrent_calls_spawn_once() {
+      let checks_ready = Arc::new(Barrier::new(2));
+      let provider_checks_ready = checks_ready.clone();
+      let (manager, dir, _events) = make_manager_with_provider(move || {
+         provider_checks_ready.wait();
+         Ok(connected_status(false, false))
+      });
+      let (server, path, url) = make_mock_download(&dir).await;
+      manager
+         .create_with_options(
+            &path,
+            &url,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      let (first, second) = tokio::join!(manager.start(&path), manager.start(&path));
+
+      assert_eq!(first.unwrap().download.status, DownloadStatus::InProgress);
+      assert_eq!(second.unwrap().download.status, DownloadStatus::InProgress);
+      wait_for_download(&manager, &path).await;
+      assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
+      server.verify().await;
+   }
+
+   #[tokio::test]
+   async fn test_start_restricted_canceled_during_check_does_not_spawn() {
+      let check_entered = Arc::new(Barrier::new(2));
+      let release_check = Arc::new(Barrier::new(2));
+      let provider_check_entered = check_entered.clone();
+      let provider_release_check = release_check.clone();
+      let (manager, dir, _events) = make_manager_with_provider(move || {
+         provider_check_entered.wait();
+         provider_release_check.wait();
+         Ok(connected_status(false, false))
+      });
+      let server = MockServer::start().await;
+      Mock::given(method("GET"))
+         .and(wm_path("/file.mp4"))
+         .respond_with(ResponseTemplate::new(200).set_body_bytes(MOCK_BODY.to_vec()))
+         .expect(0)
+         .mount(&server)
+         .await;
+      let path = dir.path().join("file.mp4").to_string_lossy().into_owned();
+      let url = format!("{}/file.mp4", server.uri());
+      manager
+         .create_with_options(
+            &path,
+            &url,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      let cancel_manager = manager.clone();
+      let cancel_path = path.clone();
+      let wait_for_check = check_entered.clone();
+      let cancel = async move {
+         tokio::task::spawn_blocking(move || wait_for_check.wait())
+            .await
+            .unwrap();
+         let response = cancel_manager.cancel(&cancel_path).unwrap();
+         release_check.wait();
+         response
+      };
+      let (start_result, cancel_response) = tokio::join!(manager.start(&path), cancel);
+
+      assert!(matches!(start_result, Err(Error::NotFound(_))));
+      assert_eq!(cancel_response.download.status, DownloadStatus::Canceled);
+      assert!(manager.store.find_by_path(&path).unwrap().is_none());
+      assert!(!Path::new(&format!("{}{}", path, DOWNLOAD_SUFFIX)).exists());
+      server.verify().await;
+   }
+
+   #[tokio::test]
    async fn test_start_restricted_rejects_metered_connection_without_state_change() {
       let (manager, _dir, events) =
          make_manager_with_provider(|| Ok(connected_status(true, false)));
@@ -928,6 +1025,34 @@ mod tests {
       let response = manager.resume(&path).await.unwrap();
 
       assert_eq!(response.download.status, DownloadStatus::InProgress);
+      wait_for_download(&manager, &path).await;
+      assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
+      server.verify().await;
+   }
+
+   #[tokio::test]
+   async fn test_resume_restricted_concurrent_calls_spawn_once() {
+      let checks_ready = Arc::new(Barrier::new(2));
+      let provider_checks_ready = checks_ready.clone();
+      let (manager, dir, _events) = make_manager_with_provider(move || {
+         provider_checks_ready.wait();
+         Ok(connected_status(false, false))
+      });
+      let (server, path, url) = make_mock_download(&dir).await;
+      seed_with_url_and_options(
+         &manager,
+         &path,
+         &url,
+         DownloadStatus::Paused,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
+
+      let (first, second) = tokio::join!(manager.resume(&path), manager.resume(&path));
+
+      assert_eq!(first.unwrap().download.status, DownloadStatus::InProgress);
+      assert_eq!(second.unwrap().download.status, DownloadStatus::InProgress);
       wait_for_download(&manager, &path).await;
       assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
       server.verify().await;

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -410,10 +410,13 @@ mod tests {
    use super::*;
    use connectivity::{ConnectionStatus, ConnectionType};
    use std::sync::Mutex;
+   use std::time::Duration;
    use tempfile::TempDir;
+   use wiremock::matchers::{method, path as wm_path};
+   use wiremock::{Mock, MockServer, ResponseTemplate};
 
    const VALID_URL: &str = "https://example.com/file.mp4";
-   const LOCAL_URL: &str = "http://127.0.0.1:9/file.mp4";
+   const MOCK_BODY: &[u8] = b"manager test download";
 
    type EventLog = Arc<Mutex<Vec<DownloadItem>>>;
 
@@ -449,6 +452,33 @@ mod tests {
 
    fn unexpected_connectivity_check() -> connectivity::Result<ConnectionStatus> {
       panic!("connectivity should not be checked")
+   }
+
+   async fn make_mock_download(dir: &TempDir) -> (MockServer, String, String) {
+      let server = MockServer::start().await;
+      Mock::given(method("GET"))
+         .and(wm_path("/file.mp4"))
+         .respond_with(ResponseTemplate::new(200).set_body_bytes(MOCK_BODY.to_vec()))
+         .expect(1)
+         .mount(&server)
+         .await;
+
+      let path = dir.path().join("file.mp4").to_string_lossy().into_owned();
+      let url = format!("{}/file.mp4", server.uri());
+      (server, path, url)
+   }
+
+   async fn wait_for_download(manager: &DownloadManager, path: &str) {
+      tokio::time::timeout(Duration::from_secs(5), async {
+         loop {
+            if manager.store.find_by_path(path).unwrap().is_none() {
+               break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+         }
+      })
+      .await
+      .expect("mock download did not complete");
    }
 
    fn event_log(events: &EventLog) -> Vec<DownloadItem> {
@@ -636,31 +666,39 @@ mod tests {
 
    #[tokio::test]
    async fn test_start_unrestricted_skips_connectivity_check() {
-      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
-      manager.create("/tmp/file.mp4", LOCAL_URL).unwrap();
+      let (manager, dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let (server, path, url) = make_mock_download(&dir).await;
+      manager.create(&path, &url).unwrap();
 
-      let response = manager.start("/tmp/file.mp4").await.unwrap();
+      let response = manager.start(&path).await.unwrap();
 
       assert_eq!(response.download.status, DownloadStatus::InProgress);
+      wait_for_download(&manager, &path).await;
+      assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
+      server.verify().await;
    }
 
    #[tokio::test]
    async fn test_start_restricted_allows_unmetered_connection() {
-      let (manager, _dir, _events) =
+      let (manager, dir, _events) =
          make_manager_with_provider(|| Ok(connected_status(false, false)));
+      let (server, path, url) = make_mock_download(&dir).await;
       manager
          .create_with_options(
-            "/tmp/file.mp4",
-            LOCAL_URL,
+            &path,
+            &url,
             CreateOptions {
                allow_metered: false,
             },
          )
          .unwrap();
 
-      let response = manager.start("/tmp/file.mp4").await.unwrap();
+      let response = manager.start(&path).await.unwrap();
 
       assert_eq!(response.download.status, DownloadStatus::InProgress);
+      wait_for_download(&manager, &path).await;
+      assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
+      server.verify().await;
    }
 
    #[tokio::test]

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -499,10 +499,20 @@ mod tests {
       status: DownloadStatus,
       options: CreateOptions,
    ) {
+      seed_with_url_and_options(manager, path, VALID_URL, status, options);
+   }
+
+   fn seed_with_url_and_options(
+      manager: &DownloadManager,
+      path: &str,
+      url: &str,
+      status: DownloadStatus,
+      options: CreateOptions,
+   ) {
       manager
          .store
          .create(DownloadRecord {
-            url: VALID_URL.to_string(),
+            url: url.to_string(),
             path: path.to_string(),
             options,
             received_bytes: 0,
@@ -851,6 +861,49 @@ mod tests {
 
       let stored = manager.store.find_by_path(path).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::Idle);
+   }
+
+   #[tokio::test]
+   async fn test_resume_unrestricted_skips_connectivity_check() {
+      let (manager, dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let (server, path, url) = make_mock_download(&dir).await;
+      seed_with_url_and_options(
+         &manager,
+         &path,
+         &url,
+         DownloadStatus::Paused,
+         CreateOptions::default(),
+      );
+
+      let response = manager.resume(&path).await.unwrap();
+
+      assert_eq!(response.download.status, DownloadStatus::InProgress);
+      wait_for_download(&manager, &path).await;
+      assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
+      server.verify().await;
+   }
+
+   #[tokio::test]
+   async fn test_resume_restricted_allows_unmetered_connection() {
+      let (manager, dir, _events) =
+         make_manager_with_provider(|| Ok(connected_status(false, false)));
+      let (server, path, url) = make_mock_download(&dir).await;
+      seed_with_url_and_options(
+         &manager,
+         &path,
+         &url,
+         DownloadStatus::Paused,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
+
+      let response = manager.resume(&path).await.unwrap();
+
+      assert_eq!(response.download.status, DownloadStatus::InProgress);
+      wait_for_download(&manager, &path).await;
+      assert_eq!(fs::read(&path).unwrap(), MOCK_BODY);
+      server.verify().await;
    }
 
    #[tokio::test]

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -12,6 +12,7 @@ use crate::store::DownloadStore;
 use crate::validate;
 
 type HttpClient = reqwest_middleware::ClientWithMiddleware;
+type ConnectionStatusProvider = fn() -> connectivity::Result<connectivity::ConnectionStatus>;
 
 pub(crate) static DOWNLOAD_SUFFIX: &str = ".download";
 
@@ -24,6 +25,7 @@ pub struct DownloadManager {
    pub(crate) http_client: HttpClient,
    pub(crate) store: DownloadStore,
    pub(crate) on_changed: OnChanged,
+   connection_status: ConnectionStatusProvider,
 }
 
 impl DownloadManager {
@@ -33,6 +35,14 @@ impl DownloadManager {
    /// - `data_dir` - Directory where `downloads.json` will be stored.
    /// - `on_changed` - Callback invoked on every state/progress change.
    pub fn new(data_dir: PathBuf, on_changed: OnChanged) -> Self {
+      Self::with_connection_status_provider(data_dir, on_changed, connectivity::connection_status)
+   }
+
+   fn with_connection_status_provider(
+      data_dir: PathBuf,
+      on_changed: OnChanged,
+      connection_status: ConnectionStatusProvider,
+   ) -> Self {
       let store = DownloadStore::new(data_dir.join("downloads.json"));
       if let Err(e) = store.load() {
          warn!("Failed to load download store: {}", e);
@@ -46,6 +56,7 @@ impl DownloadManager {
          http_client,
          store,
          on_changed,
+         connection_status,
       }
    }
 
@@ -111,6 +122,7 @@ impl DownloadManager {
          None => Ok(DownloadRecord {
             url: String::new(),
             path: path.to_string(),
+            options: CreateOptions::default(),
             received_bytes: 0,
             total_bytes: None,
             status: DownloadStatus::Pending,
@@ -129,6 +141,23 @@ impl DownloadManager {
    /// # Returns
    /// The download operation.
    pub fn create(&self, path: &str, url: &str) -> crate::Result<DownloadActionResponse> {
+      self.create_with_options(path, url, CreateOptions::default())
+   }
+
+   /// Creates a download operation with network policy options.
+   ///
+   /// Existing records are returned unchanged, including their original options.
+   ///
+   /// # Arguments
+   /// - `path` - The download path.
+   /// - `url` - The download URL for the resource.
+   /// - `options` - Network policy persisted with the download.
+   pub fn create_with_options(
+      &self,
+      path: &str,
+      url: &str,
+      options: CreateOptions,
+   ) -> crate::Result<DownloadActionResponse> {
       validate::path(path)?;
       validate::url(url)?;
 
@@ -143,6 +172,7 @@ impl DownloadManager {
       let item = self.store.create(DownloadRecord {
          url: url.to_string(),
          path: path.to_string(),
+         options,
          received_bytes: 0,
          total_bytes: None,
          status: DownloadStatus::Idle,
@@ -169,7 +199,10 @@ impl DownloadManager {
          .ok_or_else(|| Error::NotFound(path.to_string()))?;
       match item.status {
          // Allow download to be started when idle.
-         DownloadStatus::Idle => self.spawn_download(item, "failed to start"),
+         DownloadStatus::Idle => {
+            self.ensure_network_allowed(&item)?;
+            self.spawn_download(item, "failed to start")
+         }
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
@@ -196,7 +229,10 @@ impl DownloadManager {
          .ok_or_else(|| Error::NotFound(path.to_string()))?;
       match item.status {
          // Allow download to be resumed when paused.
-         DownloadStatus::Paused => self.spawn_download(item, "failed to resume"),
+         DownloadStatus::Paused => {
+            self.ensure_network_allowed(&item)?;
+            self.spawn_download(item, "failed to resume")
+         }
 
          // Return current state if in any other state.
          _ => Ok(DownloadActionResponse::with_expected_status(
@@ -237,6 +273,23 @@ impl DownloadManager {
       });
 
       Ok(DownloadActionResponse::new(public_item))
+   }
+
+   fn ensure_network_allowed(&self, item: &DownloadRecord) -> crate::Result<()> {
+      if item.options.allow_metered {
+         return Ok(());
+      }
+
+      let status = (self.connection_status)()?;
+
+      if !status.connected {
+         return Err(Error::NetworkUnavailable);
+      }
+      if status.metered || status.constrained {
+         return Err(Error::NetworkRestricted);
+      }
+
+      Ok(())
    }
 
    ///
@@ -350,22 +403,47 @@ fn filename(path: &str) -> &str {
 #[cfg(test)]
 mod tests {
    use super::*;
+   use connectivity::{ConnectionStatus, ConnectionType};
    use std::sync::Mutex;
    use tempfile::TempDir;
 
    const VALID_URL: &str = "https://example.com/file.mp4";
+   const LOCAL_URL: &str = "http://127.0.0.1:9/file.mp4";
 
    type EventLog = Arc<Mutex<Vec<DownloadItem>>>;
 
    fn make_manager() -> (DownloadManager, TempDir, EventLog) {
+      make_manager_with_provider(|| Ok(ConnectionStatus::disconnected()))
+   }
+
+   fn make_manager_with_provider(
+      connection_status: ConnectionStatusProvider,
+   ) -> (DownloadManager, TempDir, EventLog) {
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
       let captured = events.clone();
       let on_changed: OnChanged = Arc::new(move |event| {
          captured.lock().unwrap().push(event);
       });
-      let manager = DownloadManager::new(dir.path().to_path_buf(), on_changed);
+      let manager = DownloadManager::with_connection_status_provider(
+         dir.path().to_path_buf(),
+         on_changed,
+         connection_status,
+      );
       (manager, dir, events)
+   }
+
+   fn connected_status(metered: bool, constrained: bool) -> ConnectionStatus {
+      ConnectionStatus {
+         connected: true,
+         metered,
+         constrained,
+         connection_type: ConnectionType::Wifi,
+      }
+   }
+
+   fn unexpected_connectivity_check() -> connectivity::Result<ConnectionStatus> {
+      panic!("connectivity should not be checked")
    }
 
    fn event_log(events: &EventLog) -> Vec<DownloadItem> {
@@ -377,11 +455,21 @@ mod tests {
    }
 
    fn seed(manager: &DownloadManager, path: &str, status: DownloadStatus) {
+      seed_with_options(manager, path, status, CreateOptions::default());
+   }
+
+   fn seed_with_options(
+      manager: &DownloadManager,
+      path: &str,
+      status: DownloadStatus,
+      options: CreateOptions,
+   ) {
       manager
          .store
          .create(DownloadRecord {
             url: VALID_URL.to_string(),
             path: path.to_string(),
+            options,
             received_bytes: 0,
             total_bytes: None,
             status,
@@ -433,6 +521,7 @@ mod tests {
          .unwrap();
       assert_eq!(stored.status, DownloadStatus::Idle);
       assert_eq!(stored.url, VALID_URL);
+      assert!(stored.options.allow_metered);
 
       let log = event_log(&events);
       assert_eq!(log.len(), 1);
@@ -458,6 +547,42 @@ mod tests {
 
       // Only the first create emitted a change event.
       assert_eq!(event_log(&events).len(), 1);
+   }
+
+   #[test]
+   fn test_create_with_options_persists_network_policy() {
+      let (manager, _dir, _events) = make_manager();
+      let options = CreateOptions {
+         allow_metered: false,
+      };
+
+      manager
+         .create_with_options("/tmp/file.mp4", VALID_URL, options)
+         .unwrap();
+
+      let stored = manager
+         .store
+         .find_by_path("/tmp/file.mp4")
+         .unwrap()
+         .unwrap();
+      assert_eq!(stored.options, options);
+   }
+
+   #[test]
+   fn test_create_existing_does_not_overwrite_options() {
+      let (manager, _dir, _events) = make_manager();
+      let path = "/tmp/file.mp4";
+      let restricted = CreateOptions {
+         allow_metered: false,
+      };
+      manager
+         .create_with_options(path, VALID_URL, restricted)
+         .unwrap();
+
+      manager.create(path, VALID_URL).unwrap();
+
+      let stored = manager.store.find_by_path(path).unwrap().unwrap();
+      assert_eq!(stored.options, restricted);
    }
 
    #[test]
@@ -504,6 +629,146 @@ mod tests {
       assert_eq!(stored.status, DownloadStatus::InProgress);
    }
 
+   #[tokio::test]
+   async fn test_start_unrestricted_skips_connectivity_check() {
+      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      manager.create("/tmp/file.mp4", LOCAL_URL).unwrap();
+
+      let response = manager.start("/tmp/file.mp4").unwrap();
+
+      assert_eq!(response.download.status, DownloadStatus::InProgress);
+   }
+
+   #[tokio::test]
+   async fn test_start_restricted_allows_unmetered_connection() {
+      let (manager, _dir, _events) =
+         make_manager_with_provider(|| Ok(connected_status(false, false)));
+      manager
+         .create_with_options(
+            "/tmp/file.mp4",
+            LOCAL_URL,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      let response = manager.start("/tmp/file.mp4").unwrap();
+
+      assert_eq!(response.download.status, DownloadStatus::InProgress);
+   }
+
+   #[test]
+   fn test_start_restricted_rejects_metered_connection_without_state_change() {
+      let (manager, _dir, events) =
+         make_manager_with_provider(|| Ok(connected_status(true, false)));
+      let path = "/tmp/file.mp4";
+      manager
+         .create_with_options(
+            path,
+            VALID_URL,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+      clear_events(&events);
+
+      assert!(matches!(manager.start(path), Err(Error::NetworkRestricted)));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Idle
+      );
+      assert!(event_log(&events).is_empty());
+   }
+
+   #[test]
+   fn test_start_restricted_rejects_constrained_connection() {
+      let (manager, _dir, _events) =
+         make_manager_with_provider(|| Ok(connected_status(false, true)));
+      let path = "/tmp/file.mp4";
+      manager
+         .create_with_options(
+            path,
+            VALID_URL,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      assert!(matches!(manager.start(path), Err(Error::NetworkRestricted)));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Idle
+      );
+   }
+
+   #[test]
+   fn test_start_restricted_rejects_disconnected_network() {
+      let (manager, _dir, _events) = make_manager();
+      let path = "/tmp/file.mp4";
+      manager
+         .create_with_options(
+            path,
+            VALID_URL,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      assert!(matches!(
+         manager.start(path),
+         Err(Error::NetworkUnavailable)
+      ));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Idle
+      );
+   }
+
+   #[test]
+   fn test_start_restricted_propagates_connectivity_error() {
+      let (manager, _dir, _events) = make_manager_with_provider(|| {
+         Err(connectivity::Error::DetectionFailed {
+            message: "backend unavailable".to_string(),
+            code: None,
+         })
+      });
+      let path = "/tmp/file.mp4";
+      manager
+         .create_with_options(
+            path,
+            VALID_URL,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      assert!(matches!(manager.start(path), Err(Error::Connectivity(_))));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Idle
+      );
+   }
+
+   #[test]
+   fn test_start_from_non_idle_skips_connectivity_check() {
+      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      seed_with_options(
+         &manager,
+         "/tmp/file.mp4",
+         DownloadStatus::InProgress,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
+
+      manager.start("/tmp/file.mp4").unwrap();
+   }
+
    // ---------- resume ----------
 
    #[test]
@@ -534,6 +799,31 @@ mod tests {
 
       let stored = manager.store.find_by_path(path).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::Idle);
+   }
+
+   #[test]
+   fn test_resume_restricted_rejects_metered_connection_without_state_change() {
+      let (manager, _dir, events) =
+         make_manager_with_provider(|| Ok(connected_status(true, false)));
+      let path = "/tmp/file.mp4";
+      seed_with_options(
+         &manager,
+         path,
+         DownloadStatus::Paused,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
+
+      assert!(matches!(
+         manager.resume(path),
+         Err(Error::NetworkRestricted)
+      ));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Paused
+      );
+      assert!(event_log(&events).is_empty());
    }
 
    // ---------- pause ----------

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -501,6 +501,13 @@ mod tests {
       make_mock_download_expecting(dir, 1).await
    }
 
+   async fn verify_no_requests(server: &MockServer) {
+      // `#[tokio::test]` uses a current-thread runtime, so a newly spawned
+      // downloader may not be polled before an immediate verification.
+      tokio::time::sleep(Duration::from_millis(100)).await;
+      server.verify().await;
+   }
+
    async fn wait_for_download(manager: &DownloadManager, path: &str) {
       tokio::time::timeout(Duration::from_secs(5), async {
          loop {
@@ -829,7 +836,7 @@ mod tests {
       assert_eq!(cancel_response.download.status, DownloadStatus::Canceled);
       assert!(manager.store.find_by_path(&path).unwrap().is_none());
       assert!(!Path::new(&format!("{}{}", path, DOWNLOAD_SUFFIX)).exists());
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -856,7 +863,7 @@ mod tests {
          DownloadStatus::Idle
       );
       assert!(event_log(&events).is_empty());
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -882,7 +889,7 @@ mod tests {
          manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -907,7 +914,7 @@ mod tests {
          manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -937,7 +944,7 @@ mod tests {
          manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -962,7 +969,7 @@ mod tests {
          manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Idle
       );
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -986,7 +993,7 @@ mod tests {
          manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::InProgress
       );
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    // ---------- resume ----------
@@ -1027,7 +1034,7 @@ mod tests {
 
       let stored = manager.store.find_by_path(&path).unwrap().unwrap();
       assert_eq!(stored.status, DownloadStatus::Idle);
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -1124,7 +1131,7 @@ mod tests {
          DownloadStatus::Paused
       );
       assert!(event_log(&events).is_empty());
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    #[tokio::test]
@@ -1149,7 +1156,7 @@ mod tests {
          manager.store.find_by_path(&path).unwrap().unwrap().status,
          DownloadStatus::Paused
       );
-      server.verify().await;
+      verify_no_requests(&server).await;
    }
 
    // ---------- pause ----------

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -316,7 +316,7 @@ impl DownloadManager {
       if !status.connected {
          return Err(Error::NetworkUnavailable);
       }
-      if status.metered || status.constrained {
+      if status.metered != Some(false) || status.constrained != Some(false) {
          return Err(Error::NetworkRestricted);
       }
 
@@ -468,6 +468,13 @@ mod tests {
    }
 
    fn connected_status(metered: bool, constrained: bool) -> ConnectionStatus {
+      connected_status_with_policy(Some(metered), Some(constrained))
+   }
+
+   fn connected_status_with_policy(
+      metered: Option<bool>,
+      constrained: Option<bool>,
+   ) -> ConnectionStatus {
       ConnectionStatus {
          connected: true,
          metered,
@@ -893,6 +900,34 @@ mod tests {
    }
 
    #[tokio::test]
+   async fn test_start_restricted_rejects_unknown_metering() {
+      let (manager, dir, events) =
+         make_manager_with_provider(|| Ok(connected_status_with_policy(None, Some(false))));
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
+      manager
+         .create_with_options(
+            &path,
+            &url,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+      clear_events(&events);
+
+      assert!(matches!(
+         manager.start(&path).await,
+         Err(Error::NetworkRestricted)
+      ));
+      assert_eq!(
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
+         DownloadStatus::Idle
+      );
+      assert!(event_log(&events).is_empty());
+      verify_no_requests(&server).await;
+   }
+
+   #[tokio::test]
    async fn test_start_restricted_rejects_disconnected_network() {
       let (manager, dir, _events) = make_manager();
       let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
@@ -1111,6 +1146,33 @@ mod tests {
    #[tokio::test]
    async fn test_resume_restricted_rejects_metered_connection_without_state_change() {
       let (manager, dir, events) = make_manager_with_provider(|| Ok(connected_status(true, false)));
+      let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
+      seed_with_url_and_options(
+         &manager,
+         &path,
+         &url,
+         DownloadStatus::Paused,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
+
+      assert!(matches!(
+         manager.resume(&path).await,
+         Err(Error::NetworkRestricted)
+      ));
+      assert_eq!(
+         manager.store.find_by_path(&path).unwrap().unwrap().status,
+         DownloadStatus::Paused
+      );
+      assert!(event_log(&events).is_empty());
+      verify_no_requests(&server).await;
+   }
+
+   #[tokio::test]
+   async fn test_resume_restricted_rejects_unknown_constraint() {
+      let (manager, dir, events) =
+         make_manager_with_provider(|| Ok(connected_status_with_policy(Some(false), None)));
       let (server, path, url) = make_mock_download_expecting(&dir, 0).await;
       seed_with_url_and_options(
          &manager,

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -35,6 +35,13 @@ impl DownloadManager {
    /// - `data_dir` - Directory where `downloads.json` will be stored.
    /// - `on_changed` - Callback invoked on every state/progress change.
    pub fn new(data_dir: PathBuf, on_changed: OnChanged) -> Self {
+      #[cfg(target_os = "macos")]
+      {
+         // Start the path monitor early so its initial asynchronous update has
+         // normally populated the cache before the first policy check.
+         let _ = connectivity::connection_status();
+      }
+
       Self::with_connection_status_provider(data_dir, on_changed, connectivity::connection_status)
    }
 

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -310,10 +310,8 @@ impl DownloadManager {
       let connection_status = self.connection_status.clone();
       let status = tokio::task::spawn_blocking(move || connection_status())
          .await
-         .map_err(|error| connectivity::Error::DetectionFailed {
-            message: format!("connection status worker failed: {error}"),
-            code: None,
-         })??;
+         .map_err(|error| Error::Internal(format!("Connectivity worker failed: {error}")))?
+         .map_err(|error| Error::Connectivity(error.to_string()))?;
 
       if !status.connected {
          return Err(Error::NetworkUnavailable);
@@ -941,6 +939,27 @@ mod tests {
    }
 
    #[tokio::test]
+   async fn test_start_restricted_fails_closed_when_connectivity_worker_panics() {
+      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let path = "/tmp/file.mp4";
+      manager
+         .create_with_options(
+            path,
+            VALID_URL,
+            CreateOptions {
+               allow_metered: false,
+            },
+         )
+         .unwrap();
+
+      assert!(matches!(manager.start(path).await, Err(Error::Internal(_))));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Idle
+      );
+   }
+
+   #[tokio::test]
    async fn test_start_from_non_idle_skips_connectivity_check() {
       let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
       seed_with_options(
@@ -1081,6 +1100,29 @@ mod tests {
          DownloadStatus::Paused
       );
       assert!(event_log(&events).is_empty());
+   }
+
+   #[tokio::test]
+   async fn test_resume_restricted_fails_closed_when_connectivity_worker_panics() {
+      let (manager, _dir, _events) = make_manager_with_provider(unexpected_connectivity_check);
+      let path = "/tmp/file.mp4";
+      seed_with_options(
+         &manager,
+         path,
+         DownloadStatus::Paused,
+         CreateOptions {
+            allow_metered: false,
+         },
+      );
+
+      assert!(matches!(
+         manager.resume(path).await,
+         Err(Error::Internal(_))
+      ));
+      assert_eq!(
+         manager.store.find_by_path(path).unwrap().unwrap().status,
+         DownloadStatus::Paused
+      );
    }
 
    // ---------- pause ----------

--- a/crates/download-manager/src/models.rs
+++ b/crates/download-manager/src/models.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Options that control when a download is allowed to use the network.
+///
+/// Options are fixed when the download is created and remain unchanged for the
+/// lifetime of its persisted record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateOptions {
@@ -47,6 +50,8 @@ pub(crate) struct DownloadRecord {
 pub struct DownloadItem {
    pub url: String,
    pub path: String,
+   /// Network policy fixed when the download was created.
+   pub options: CreateOptions,
    pub received_bytes: u64,
    pub total_bytes: Option<u64>,
    pub progress: f64,
@@ -128,6 +133,7 @@ impl DownloadRecord {
       DownloadItem {
          url: self.url.clone(),
          path: self.path.clone(),
+         options: self.options,
          received_bytes: self.received_bytes,
          total_bytes: self.total_bytes,
          progress,
@@ -210,12 +216,18 @@ mod tests {
    #[test]
    fn test_to_item_with_known_size() {
       let mut record = sample_record();
+      record.options.allow_metered = false;
       record.received_bytes = 500;
       record.total_bytes = Some(1000);
       let item = record.to_item();
+      assert!(!item.options.allow_metered);
       assert_eq!(item.progress, 50.0);
       assert_eq!(item.received_bytes, 500);
       assert_eq!(item.total_bytes, Some(1000));
+      assert_eq!(
+         serde_json::to_value(&item).unwrap()["options"]["allowMetered"],
+         false
+      );
    }
 
    #[test]

--- a/crates/download-manager/src/models.rs
+++ b/crates/download-manager/src/models.rs
@@ -1,6 +1,27 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Options that control when a download is allowed to use the network.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateOptions {
+   /// Whether the download may start on metered or constrained connections.
+   #[serde(default = "default_allow_metered")]
+   pub allow_metered: bool,
+}
+
+impl Default for CreateOptions {
+   fn default() -> Self {
+      Self {
+         allow_metered: true,
+      }
+   }
+}
+
+const fn default_allow_metered() -> bool {
+   true
+}
+
 /// Persisted download record. Stored in `downloads.json`.
 ///
 /// Does not contain `progress` — that is a derived value only present in
@@ -10,6 +31,8 @@ use std::fmt;
 pub(crate) struct DownloadRecord {
    pub url: String,
    pub path: String,
+   #[serde(default)]
+   pub options: CreateOptions,
    #[serde(default)]
    pub received_bytes: u64,
    #[serde(default)]
@@ -136,6 +159,7 @@ mod tests {
       DownloadRecord {
          url: "http://example.com/file.mp4".to_string(),
          path: "/tmp/file.mp4".to_string(),
+         options: CreateOptions::default(),
          received_bytes: 0,
          total_bytes: None,
          status: DownloadStatus::Idle,
@@ -230,6 +254,29 @@ mod tests {
       let record: DownloadRecord = serde_json::from_str(json).unwrap();
       assert_eq!(record.received_bytes, 0);
       assert_eq!(record.total_bytes, None);
+      assert!(record.options.allow_metered);
+   }
+
+   #[test]
+   fn test_create_options_default_allows_metered_connections() {
+      assert!(CreateOptions::default().allow_metered);
+
+      let options: CreateOptions = serde_json::from_str("{}").unwrap();
+      assert!(options.allow_metered);
+   }
+
+   #[test]
+   fn test_create_options_round_trip_restriction() {
+      let options = CreateOptions {
+         allow_metered: false,
+      };
+      let json = serde_json::to_string(&options).unwrap();
+
+      assert_eq!(json, r#"{"allowMetered":false}"#);
+      assert_eq!(
+         serde_json::from_str::<CreateOptions>(&json).unwrap(),
+         options
+      );
    }
 
    #[test]

--- a/crates/download-manager/src/store.rs
+++ b/crates/download-manager/src/store.rs
@@ -3,7 +3,13 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use crate::Error;
-use crate::models::DownloadRecord;
+use crate::models::{DownloadRecord, DownloadStatus};
+
+pub(crate) enum UpdateIfStatusResult {
+   Updated(DownloadRecord),
+   Unchanged(DownloadRecord),
+   NotFound,
+}
 
 /// Thread-safe JSON file store for download records, mirroring iOS `DownloadStore`.
 #[derive(Clone, Debug)]
@@ -73,6 +79,31 @@ impl DownloadStore {
       }
       save_inner(&inner)?;
       Ok(())
+   }
+
+   pub fn update_if_status(
+      &self,
+      path: &str,
+      expected_status: DownloadStatus,
+      new_status: DownloadStatus,
+   ) -> crate::Result<UpdateIfStatusResult> {
+      let mut inner = self
+         .inner
+         .lock()
+         .map_err(|e| Error::Store(format!("Lock poisoned: {}", e)))?;
+
+      let Some(existing) = inner.downloads.iter_mut().find(|item| item.path == path) else {
+         return Ok(UpdateIfStatusResult::NotFound);
+      };
+
+      if existing.status != expected_status {
+         return Ok(UpdateIfStatusResult::Unchanged(existing.clone()));
+      }
+
+      existing.status = new_status;
+      let updated = existing.clone();
+      save_inner(&inner)?;
+      Ok(UpdateIfStatusResult::Updated(updated))
    }
 
    pub fn update_no_persist(&self, item: DownloadRecord) -> crate::Result<()> {
@@ -252,6 +283,78 @@ mod tests {
       let unknown = sample_record("/tmp/unknown.mp4");
       assert!(store.update(unknown).is_ok());
       assert_eq!(store.list().unwrap().len(), 1);
+   }
+
+   #[test]
+   fn test_update_if_status_updates_matching_record() {
+      let (store, dir) = temp_store();
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
+
+      let result = store
+         .update_if_status(
+            "/tmp/file.mp4",
+            DownloadStatus::Idle,
+            DownloadStatus::InProgress,
+         )
+         .unwrap();
+
+      assert!(matches!(
+         result,
+         UpdateIfStatusResult::Updated(item)
+            if item.status == DownloadStatus::InProgress
+      ));
+
+      let reloaded = DownloadStore::new(dir.path().join("downloads.json"));
+      reloaded.load().unwrap();
+      assert_eq!(
+         reloaded
+            .find_by_path("/tmp/file.mp4")
+            .unwrap()
+            .unwrap()
+            .status,
+         DownloadStatus::InProgress
+      );
+   }
+
+   #[test]
+   fn test_update_if_status_returns_current_record_on_mismatch() {
+      let (store, _dir) = temp_store();
+      let mut item = sample_record("/tmp/file.mp4");
+      item.status = DownloadStatus::Paused;
+      store.create(item).unwrap();
+
+      let result = store
+         .update_if_status(
+            "/tmp/file.mp4",
+            DownloadStatus::Idle,
+            DownloadStatus::InProgress,
+         )
+         .unwrap();
+
+      assert!(matches!(
+         result,
+         UpdateIfStatusResult::Unchanged(item) if item.status == DownloadStatus::Paused
+      ));
+      assert_eq!(
+         store.find_by_path("/tmp/file.mp4").unwrap().unwrap().status,
+         DownloadStatus::Paused
+      );
+   }
+
+   #[test]
+   fn test_update_if_status_returns_not_found_for_unknown_path() {
+      let (store, _dir) = temp_store();
+
+      assert!(matches!(
+         store
+            .update_if_status(
+               "/tmp/missing.mp4",
+               DownloadStatus::Idle,
+               DownloadStatus::InProgress,
+            )
+            .unwrap(),
+         UpdateIfStatusResult::NotFound
+      ));
    }
 
    #[test]

--- a/crates/download-manager/src/store.rs
+++ b/crates/download-manager/src/store.rs
@@ -155,6 +155,7 @@ mod tests {
       DownloadRecord {
          url: "https://example.com/file.mp4".to_string(),
          path: path.to_string(),
+         options: Default::default(),
          received_bytes: 0,
          total_bytes: None,
          status: DownloadStatus::Idle,
@@ -201,6 +202,20 @@ mod tests {
       let (store, dir) = temp_store();
       store.create(sample_record("/tmp/file.mp4")).unwrap();
       assert!(dir.path().join("downloads.json").exists());
+   }
+
+   #[test]
+   fn test_create_options_persist_across_reload() {
+      let (store, dir) = temp_store();
+      let mut item = sample_record("/tmp/file.mp4");
+      item.options.allow_metered = false;
+      store.create(item).unwrap();
+
+      let reloaded = DownloadStore::new(dir.path().join("downloads.json"));
+      reloaded.load().unwrap();
+
+      let found = reloaded.find_by_path("/tmp/file.mp4").unwrap().unwrap();
+      assert!(!found.options.allow_metered);
    }
 
    #[test]

--- a/guest-js/actions.ts
+++ b/guest-js/actions.ts
@@ -203,6 +203,7 @@ export function attachDownload<S extends DownloadStatus>(state: DownloadState<S>
    const download = {
       url: state.url,
       path: state.path,
+      options: { ...state.options },
       receivedBytes: state.receivedBytes ?? 0,
       totalBytes: state.totalBytes ?? null,
       progress: state.progress ?? 0,

--- a/guest-js/actions.ts
+++ b/guest-js/actions.ts
@@ -2,7 +2,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { addPluginListener, invoke } from '@tauri-apps/api/core';
 import {
    AllDownloadActions, allowedActions, Download, DownloadAction, DownloadActionResponse, DownloadState,
-   DownloadStatus, DownloadWithAnyStatus, isTerminal, ListenOptions,
+   DownloadStatus, DownloadWithAnyStatus, isTerminal, ListenOptions, CreateOptions,
 } from './types';
 
 export const DOWNLOAD_EVENT_NAME = 'tauri-plugin-download:changed';
@@ -167,8 +167,14 @@ const actions = {
       return unlisten;
    },
 
-   async create(url: string) {
-      return sendAction(DownloadAction.Create, { path: this.path, url });
+   async create(url: string, options?: CreateOptions) {
+      const args: Record<string, unknown> = { path: this.path, url };
+
+      if (options) {
+         args.options = options;
+      }
+
+      return sendAction(DownloadAction.Create, args);
    },
 
    async start() {

--- a/guest-js/actions.ts
+++ b/guest-js/actions.ts
@@ -7,6 +7,14 @@ import {
 
 export const DOWNLOAD_EVENT_NAME = 'tauri-plugin-download:changed';
 
+type SerializedDownloadState<S extends DownloadStatus> =
+   Omit<DownloadState<S>, 'options' | 'receivedBytes' | 'totalBytes' | 'progress'> & {
+      readonly options?: Readonly<CreateOptions>;
+      receivedBytes?: number;
+      totalBytes?: number | null;
+      progress?: number;
+   };
+
 /**
  * Manages subscriptions to download events from Rust and mobile plugins (iOS/Android),
  * and dispatching these events to registered listeners.
@@ -71,17 +79,17 @@ class DownloadEventManager {
       const isNative = await invoke<boolean>('plugin:download|is_native');
 
       if (isNative) {
-         this._pluginListener = await addPluginListener('download', 'changed', (event: DownloadState<DownloadStatus>) => {
+         this._pluginListener = await addPluginListener('download', 'changed', (event: SerializedDownloadState<DownloadStatus>) => {
             this._notifyListeners(event.path, event);
          });
       } else {
-         this._eventUnlistenFn = await listen<DownloadState<DownloadStatus>>(DOWNLOAD_EVENT_NAME, (event) => {
+         this._eventUnlistenFn = await listen<SerializedDownloadState<DownloadStatus>>(DOWNLOAD_EVENT_NAME, (event) => {
             this._notifyListeners(event.payload.path, event.payload);
          });
       }
    }
 
-   private _notifyListeners(path: string, event: DownloadState<DownloadStatus>): void {
+   private _notifyListeners(path: string, event: SerializedDownloadState<DownloadStatus>): void {
       const listeners = this._listeners.get(path);
 
       if (listeners) {
@@ -199,11 +207,11 @@ const actions = {
  *
  * @param state The de-serialized download state from the plugin
  */
-export function attachDownload<S extends DownloadStatus>(state: DownloadState<S>): Download<S> {
+export function attachDownload<S extends DownloadStatus>(state: SerializedDownloadState<S>): Download<S> {
    const download = {
       url: state.url,
       path: state.path,
-      options: { ...state.options },
+      options: { allowMetered: state.options?.allowMetered ?? true },
       receivedBytes: state.receivedBytes ?? 0,
       totalBytes: state.totalBytes ?? null,
       progress: state.progress ?? 0,

--- a/guest-js/index.test.ts
+++ b/guest-js/index.test.ts
@@ -30,6 +30,7 @@ let lastCmd = '',
 const IDLE_STATE = {
    url: 'https://example.com/file.zip',
    path: '/tmp/file.zip',
+   options: { allowMetered: true },
    receivedBytes: 0,
    totalBytes: null,
    progress: 0,
@@ -39,6 +40,7 @@ const IDLE_STATE = {
 const IN_PROGRESS_STATE = {
    url: 'https://example.com/file.zip',
    path: '/tmp/file.zip',
+   options: { allowMetered: true },
    receivedBytes: 42,
    totalBytes: 100,
    progress: 42,
@@ -48,6 +50,7 @@ const IN_PROGRESS_STATE = {
 const PAUSED_STATE = {
    url: 'https://example.com/file.zip',
    path: '/tmp/file.zip',
+   options: { allowMetered: true },
    receivedBytes: 42,
    totalBytes: 100,
    progress: 42,
@@ -77,6 +80,7 @@ beforeEach(() => {
          return {
             url: '',
             path,
+            options: { allowMetered: true },
             receivedBytes: 0,
             totalBytes: null,
             progress: 0,
@@ -263,6 +267,7 @@ describe('state machine — action availability', () => {
       const download = attachDownload({
          url: '',
          path: '/tmp/file.zip',
+         options: { allowMetered: true },
          receivedBytes: 0,
          totalBytes: null,
          progress: 0,
@@ -352,6 +357,7 @@ describe('state machine — action availability', () => {
 
       expect(download.url).toBe('https://example.com/file.zip');
       expect(download.path).toBe('/tmp/file.zip');
+      expect(download.options).toEqual({ allowMetered: true });
       expect(download.receivedBytes).toBe(42);
       expect(download.totalBytes).toBe(100);
       expect(download.progress).toBe(42);

--- a/guest-js/index.test.ts
+++ b/guest-js/index.test.ts
@@ -363,6 +363,26 @@ describe('state machine — action availability', () => {
       expect(download.progress).toBe(42);
       expect(download.status).toBe(DownloadStatus.InProgress);
    });
+
+   it('defaults missing native options to allow metered connections', () => {
+      const download = attachDownload({
+         url: 'https://example.com/file.zip',
+         path: '/tmp/file.zip',
+         progress: 42,
+         status: DownloadStatus.InProgress,
+      });
+
+      expect(download.options).toEqual({ allowMetered: true });
+   });
+
+   it('preserves an explicit metered connection restriction', () => {
+      const download = attachDownload({
+         ...IDLE_STATE,
+         options: { allowMetered: false },
+      });
+
+      expect(download.options).toEqual({ allowMetered: false });
+   });
 });
 
 describe('wrapListenerWithAutoUnlisten', () => {

--- a/guest-js/index.test.ts
+++ b/guest-js/index.test.ts
@@ -175,8 +175,20 @@ describe('download actions', () => {
       expect(lastCmd).toBe('plugin:download|create');
       expect(lastArgs.path).toBe('/tmp/unknown.zip');
       expect(lastArgs.url).toBe('https://example.com/file.zip');
+      expect(lastArgs.options).toBeUndefined();
       expect(response.isExpectedStatus).toBe(true);
       expect(response.download.status).toBe(DownloadStatus.Idle);
+   });
+
+   it('create — forwards network policy options', async () => {
+      const pending = await get('/tmp/unknown.zip');
+
+      if (!hasAction(pending, DownloadAction.Create)) {
+         throw new Error('expected create action');
+      }
+      await pending.create('https://example.com/file.zip', { allowMetered: false });
+
+      expect(lastArgs.options).toEqual({ allowMetered: false });
    });
 
    it('start — sends path, returns InProgress download', async () => {

--- a/guest-js/mocks.test.ts
+++ b/guest-js/mocks.test.ts
@@ -121,11 +121,34 @@ describe('mockDownloadPlugin', () => {
       expect(controller.getDownload('/tmp/new.zip')).toEqual({
          url: 'https://example.com/new.zip',
          path: '/tmp/new.zip',
+         options: { allowMetered: false },
          receivedBytes: 0,
          totalBytes: null,
          progress: 0,
          status: DownloadStatus.Idle,
       });
+   });
+
+   it('keeps create-time options when create is repeated', async () => {
+      const path = '/tmp/existing.zip';
+
+      const controller = mockDownloadPlugin({
+         downloads: [
+            createMockDownloadState(DownloadStatus.Idle, {
+               path,
+               options: { allowMetered: false },
+            }),
+         ],
+      });
+
+      const response = await invoke<DownloadActionResponse>('plugin:download|create', {
+         path,
+         url: 'https://example.com/recreated.zip',
+         options: { allowMetered: true },
+      });
+
+      expect(response.download.options).toEqual({ allowMetered: false });
+      expect(controller.getDownload(path).options).toEqual({ allowMetered: false });
    });
 
    it('emits mocked desktop events to download listeners', async () => {

--- a/guest-js/mocks.test.ts
+++ b/guest-js/mocks.test.ts
@@ -113,10 +113,11 @@ describe('mockDownloadPlugin', () => {
          throw new Error('expected create action');
       }
 
-      const response = await download.create('https://example.com/new.zip');
+      const response = await download.create('https://example.com/new.zip', { allowMetered: false });
 
       expect(response.isExpectedStatus).toBe(true);
       expect(response.download.status).toBe(DownloadStatus.Idle);
+      expect(controller.getLastInvocation()?.args.options).toEqual({ allowMetered: false });
       expect(controller.getDownload('/tmp/new.zip')).toEqual({
          url: 'https://example.com/new.zip',
          path: '/tmp/new.zip',

--- a/guest-js/mocks.ts
+++ b/guest-js/mocks.ts
@@ -4,6 +4,7 @@ import { DOWNLOAD_EVENT_NAME, resetDownloadEventManager } from './actions';
 import {
    DownloadAction,
    type DownloadActionResponse,
+   type CreateOptions,
    type DownloadState,
    DownloadStatus,
    expectedStatusesForAction,
@@ -108,7 +109,10 @@ type MockActionResponse<A extends DownloadAction> = Omit<DownloadActionResponse<
 const DEFAULT_URL = 'https://example.com/file.zip';
 
 function cloneDownload<S extends DownloadStatus>(download: DownloadState<S>): DownloadState<S> {
-   return { ...download };
+   return {
+      ...download,
+      options: { ...download.options },
+   };
 }
 
 function cloneDownloads(downloadsByPath: Map<string, DownloadState<DownloadStatus>>): DownloadState<DownloadStatus>[] {
@@ -121,6 +125,7 @@ function createPendingDownload(path: string): DownloadState<DownloadStatus.Pendi
    return {
       url: '',
       path,
+      options: { allowMetered: true },
       receivedBytes: 0,
       totalBytes: null,
       progress: 0,
@@ -189,6 +194,14 @@ function getUrlArg(args: Record<string, unknown>): string {
    return String(args.url ?? DEFAULT_URL);
 }
 
+function getCreateOptionsArg(args: Record<string, unknown>): Required<CreateOptions> {
+   const options = args.options as CreateOptions | undefined;
+
+   return {
+      allowMetered: options?.allowMetered ?? true,
+   };
+}
+
 function createTransitionDownload(
    currentDownload: DownloadState<DownloadStatus>,
    nextStatus: DownloadStatus,
@@ -233,6 +246,9 @@ export function createMockDownloadState(
    return {
       url: overrides.url ?? DEFAULT_URL,
       path: overrides.path ?? '/tmp/file.zip',
+      options: {
+         allowMetered: overrides.options?.allowMetered ?? true,
+      },
       receivedBytes,
       totalBytes,
       progress: computedProgress,
@@ -253,7 +269,7 @@ export function clearDownloadMocks(): void {
  *
  * This helper approximates backend/native state transitions for common test flows.
  * It is not a backend contract and does not transition downloads to `Completed`.
- * Create options are recorded in invocation history, but network-policy enforcement
+ * Create options are persisted with mocked downloads, but network-policy enforcement
  * is not simulated.
  * It only simulates the desktop event path and always returns `false` for `is_native`,
  * so tests that need the native/mobile listener branch require a separate approach.
@@ -291,6 +307,7 @@ export function mockDownloadPlugin(
             const createdDownload = {
                ...currentDownload,
                url: getUrlArg(args),
+               options: getCreateOptionsArg(args),
                status: DownloadStatus.Idle,
             };
 

--- a/guest-js/mocks.ts
+++ b/guest-js/mocks.ts
@@ -253,6 +253,8 @@ export function clearDownloadMocks(): void {
  *
  * This helper approximates backend/native state transitions for common test flows.
  * It is not a backend contract and does not transition downloads to `Completed`.
+ * Create options are recorded in invocation history, but network-policy enforcement
+ * is not simulated.
  * It only simulates the desktop event path and always returns `false` for `is_native`,
  * so tests that need the native/mobile listener branch require a separate approach.
  * Use `emitChange()` or `setDownload()` to simulate progress updates or terminal states.

--- a/guest-js/types.ts
+++ b/guest-js/types.ts
@@ -51,6 +51,9 @@ export enum DownloadAction {
 export interface DownloadState<S extends DownloadStatus> {
    url: string;
    path: string;
+
+   /** Network policy fixed when this download was created. */
+   readonly options: Readonly<Required<CreateOptions>>;
    receivedBytes: number;
    totalBytes: number | null;
    progress: number;
@@ -78,13 +81,19 @@ export interface ListenOptions {
    autoUnlisten?: boolean;
 }
 
-/** Options applied when a download is created. */
+/**
+ * Options applied when a download is first created.
+ *
+ * An existing download keeps its original options when `create()` is called
+ * again for the same path.
+ */
 export interface CreateOptions {
 
    /**
     * Whether the download may start or resume on metered or constrained
     * connections. Defaults to `true`.
     *
+    * The resolved value is exposed through `download.options.allowMetered`.
     * This option is currently enforced on desktop only.
     */
    allowMetered?: boolean;

--- a/guest-js/types.ts
+++ b/guest-js/types.ts
@@ -78,6 +78,18 @@ export interface ListenOptions {
    autoUnlisten?: boolean;
 }
 
+/** Options applied when a download is created. */
+export interface CreateOptions {
+
+   /**
+    * Whether the download may start or resume on metered or constrained
+    * connections. Defaults to `true`.
+    *
+    * This option is currently enforced on desktop only.
+    */
+   allowMetered?: boolean;
+}
+
 export interface AllDownloadActions {
 
    /**
@@ -108,7 +120,10 @@ export interface AllDownloadActions {
     * ```
     */
    [DownloadAction.Listen]: (listener: (download: DownloadWithAnyStatus) => void, options?: ListenOptions) => Promise<UnlistenFn>;
-   [DownloadAction.Create]: (url: string) => Promise<DownloadActionResponse<DownloadAction.Create>>;
+   [DownloadAction.Create]: (
+      url: string,
+      options?: CreateOptions
+   ) => Promise<DownloadActionResponse<DownloadAction.Create>>;
    [DownloadAction.Start]: () => Promise<DownloadActionResponse<DownloadAction.Start>>;
    [DownloadAction.Resume]: () => Promise<DownloadActionResponse<DownloadAction.Resume>>;
    [DownloadAction.Pause]: () => Promise<DownloadActionResponse<DownloadAction.Pause>>;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,8 +19,18 @@ pub(crate) async fn create<R: Runtime>(
    app: AppHandle<R>,
    path: String,
    url: String,
+   options: Option<CreateOptions>,
 ) -> Result<DownloadActionResponse> {
-   app.download().create(&path, &url)
+   #[cfg(desktop)]
+   {
+      app.download()
+         .create_with_options(&path, &url, options.unwrap_or_default())
+   }
+   #[cfg(mobile)]
+   {
+      let _ = options;
+      app.download().create(&path, &url)
+   }
 }
 
 #[command]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -38,7 +38,14 @@ pub(crate) async fn start<R: Runtime>(
    app: AppHandle<R>,
    path: String,
 ) -> Result<DownloadActionResponse> {
-   app.download().start(&path)
+   #[cfg(desktop)]
+   {
+      app.download().start(&path).await
+   }
+   #[cfg(mobile)]
+   {
+      app.download().start(&path)
+   }
 }
 
 #[command]
@@ -46,7 +53,14 @@ pub(crate) async fn resume<R: Runtime>(
    app: AppHandle<R>,
    path: String,
 ) -> Result<DownloadActionResponse> {
-   app.download().resume(&path)
+   #[cfg(desktop)]
+   {
+      app.download().resume(&path).await
+   }
+   #[cfg(mobile)]
+   {
+      app.download().resume(&path)
+   }
 }
 
 #[command]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ mod commands;
 mod error;
 mod models;
 
+pub use models::CreateOptions;
+
 use error::Result;
 
 #[cfg(desktop)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,7 +7,7 @@ pub use download_manager::{CreateOptions, DownloadActionResponse, DownloadItem};
 mod mobile_types {
    use serde::{Deserialize, Serialize};
 
-   #[derive(Debug, Clone, Copy, Deserialize)]
+   #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
    #[serde(rename_all = "camelCase")]
    pub struct CreateOptions {
       #[serde(default = "default_allow_metered")]

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,6 +7,7 @@ pub use download_manager::{CreateOptions, DownloadActionResponse, DownloadItem};
 mod mobile_types {
    use serde::{Deserialize, Serialize};
 
+   /// Options fixed when a download is created.
    #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
    #[serde(rename_all = "camelCase")]
    pub struct CreateOptions {
@@ -44,6 +45,8 @@ mod mobile_types {
    pub struct DownloadItem {
       pub url: String,
       pub path: String,
+      #[serde(default)]
+      pub options: CreateOptions,
       #[serde(default)]
       pub received_bytes: u64,
       #[serde(default)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,11 +1,30 @@
 // Desktop model types
 #[cfg(desktop)]
-pub use download_manager::{DownloadActionResponse, DownloadItem};
+pub use download_manager::{CreateOptions, DownloadActionResponse, DownloadItem};
 
 // Mobile model types (iOS, Android)
 #[cfg(mobile)]
 mod mobile_types {
    use serde::{Deserialize, Serialize};
+
+   #[derive(Debug, Clone, Copy, Deserialize)]
+   #[serde(rename_all = "camelCase")]
+   pub struct CreateOptions {
+      #[serde(default = "default_allow_metered")]
+      pub allow_metered: bool,
+   }
+
+   impl Default for CreateOptions {
+      fn default() -> Self {
+         Self {
+            allow_metered: true,
+         }
+      }
+   }
+
+   const fn default_allow_metered() -> bool {
+      true
+   }
 
    #[derive(Serialize)]
    #[serde(rename_all = "camelCase")]
@@ -77,4 +96,4 @@ mod mobile_types {
 }
 
 #[cfg(mobile)]
-pub use mobile_types::{CreateArgs, DownloadActionResponse, DownloadItem, PathArgs};
+pub use mobile_types::{CreateArgs, CreateOptions, DownloadActionResponse, DownloadItem, PathArgs};


### PR DESCRIPTION
Addresses #13 by adding an optional, persisted network policy for download tasks.

- Adds `CreateOptions` with `allowMetered`, defaulting to `true`.
- Persists the policy in the desktop download store, including safe defaults for existing records.
- Checks connectivity before `start()` and `resume()` when metered access is disabled.
- Rejects disconnected, metered, constrained, or indeterminate connections without changing the download state.
- Leaves active downloads running if connectivity changes after they start.
- Keeps Android and iOS behavior unchanged; they accept the option but do not currently enforce it.
- Adds TypeScript, persistence, lifecycle, and connectivity-policy tests.

Validation:
- `npm run test:ts`
- `cargo test --workspace --lib`
- `npm run rust:lint`
- `npm run eslint`
- `npm run markdownlint`
