### PR TITLE
feat: emit receivedBytes and totalBytes from the mobile download managers

### DIFF
--- a/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsScreen.kt
+++ b/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsScreen.kt
@@ -164,6 +164,14 @@ private fun DownloadRow(
          color = MaterialTheme.colorScheme.onSurfaceVariant,
       )
 
+      // A server that omits the content length leaves totalBytes null, so the
+      // total is not always known even while bytes are arriving.
+      Text(
+         text = "${formatBytes(item.receivedBytes)} / ${item.totalBytes?.let { formatBytes(it) } ?: "unknown"}",
+         style = MaterialTheme.typography.bodySmall,
+         color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+
       Spacer(modifier = Modifier.height(4.dp))
 
       val primaryAction: Pair<String, () -> Unit>? = when (item.status) {
@@ -185,5 +193,24 @@ private fun DownloadRow(
             ) { Text("Cancel") }
          }
       }
+   }
+}
+
+private val BYTE_UNITS = listOf("B", "KB", "MB", "GB", "TB")
+
+/** Formats a byte count for display, e.g. `1.5 MB`. */
+private fun formatBytes(bytes: Long): String {
+   var value = bytes.toDouble()
+   var unitIndex = 0
+
+   while (value >= 1024 && unitIndex < BYTE_UNITS.size - 1) {
+      value /= 1024
+      unitIndex++
+   }
+
+   return if (unitIndex == 0) {
+      "${value.toInt()} ${BYTE_UNITS[unitIndex]}"
+   } else {
+      String.format("%.1f %s", value, BYTE_UNITS[unitIndex])
    }
 }

--- a/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsViewModel.kt
+++ b/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsViewModel.kt
@@ -35,7 +35,11 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
 
       viewModelScope.launch {
          manager.changed.collect { item ->
-            android.util.Log.d("DownloadsViewModel", "[${File(item.path).name}] ${item.status} - ${String.format("%.0f", item.progress)}%")
+            android.util.Log.d(
+               "DownloadsViewModel",
+               "[${File(item.path).name}] ${item.status} - ${String.format("%.0f", item.progress)}%" +
+                  " (${item.receivedBytes}/${item.totalBytes ?: "unknown"} bytes)",
+            )
             _uiState.value = _uiState.value.copy(downloads = manager.list())
          }
       }

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadItem.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadItem.kt
@@ -4,8 +4,17 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * A value type that represents an item to be downloaded.
- * Used to track the status and progress of a download operation.
+ * Emit-only payload sent to the frontend. Built from a [DownloadRecord] with
+ * `progress` derived from [receivedBytes] / [totalBytes]; never persisted, so
+ * nothing internal to the download machinery leaks into the frontend contract.
+ * [totalBytes] is `null` when the server supplied no content length, and
+ * serializes as an explicit JSON `null`.
+ *
+ * No property carries a default, so every key here is written whatever
+ * `encodeDefaults` the caller's `Json` uses, rather than depending on the
+ * TypeScript layer to coalesce it (attachDownload in `guest-js/actions.ts`).
+ * `options` is the one field of `DownloadState` mobile does not emit — the
+ * desktop payload carries it, and the TypeScript layer supplies the default.
  */
 @Serializable
 data class DownloadItem(
@@ -15,18 +24,15 @@ data class DownloadItem(
    @SerialName("path")
    val path: String,
 
+   @SerialName("receivedBytes")
+   val receivedBytes: Long,
+
+   @SerialName("totalBytes")
+   val totalBytes: Long?,
+
    @SerialName("progress")
-   val progress: Double = 0.0,
+   val progress: Double,
 
    @SerialName("status")
-   val status: DownloadStatus = DownloadStatus.Idle,
-) {
-   fun withProgress(newProgress: Double): DownloadItem =
-      copy(progress = newProgress)
-
-   fun withStatus(newStatus: DownloadStatus): DownloadItem =
-      copy(
-         progress = if (newStatus == DownloadStatus.Completed) 100.0 else progress,
-         status = newStatus,
-      )
-}
+   val status: DownloadStatus,
+)

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
@@ -46,21 +46,16 @@ class DownloadManager private constructor(context: Context) {
     * Mirrors the Rust Download.init() method.
     */
    private fun reconcileStoreOnInit() {
-      val items = store.list()
-      for (item in items) {
-         if (item.status == DownloadStatus.InProgress) {
-            val tempFile = File("${item.path}${DownloadWorker.DOWNLOAD_SUFFIX}")
-            val newStatus = if (tempFile.exists()) {
-               DownloadStatus.Paused
-            } else {
-               DownloadStatus.Idle
-            }
+      val reconciled = mutableListOf<DownloadRecord>()
 
-            val updated = item.withStatus(newStatus)
-            store.update(updated)
-            Log.d(TAG, "[${File(item.path).name}] Reconciled to $newStatus")
-         }
+      for (record in store.list()) {
+         val reverted = revertInProgress(record, DownloadWorker.tempFileLength(record.path)) ?: continue
+
+         reconciled.add(reverted)
+         Log.d(TAG, "[${File(record.path).name}] Reconciled to ${reverted.status}")
       }
+
+      store.update(reconciled)
    }
 
    /**
@@ -68,7 +63,7 @@ class DownloadManager private constructor(context: Context) {
     *
     * @return The list of download operations.
     */
-   fun list(): List<DownloadItem> = store.list()
+   fun list(): List<DownloadItem> = store.list().map { it.toItem() }
 
    /**
     * Gets a download operation.
@@ -82,14 +77,13 @@ class DownloadManager private constructor(context: Context) {
     */
    fun get(path: String): DownloadItem {
       val existing = store.findByPath(path)
-      if (existing != null) return existing
+      if (existing != null) return existing.toItem()
 
-      return DownloadItem(
+      return DownloadRecord(
          url = "",
          path = path,
-         progress = 0.0,
          status = DownloadStatus.Pending,
-      )
+      ).toItem()
    }
 
    /**
@@ -103,14 +97,13 @@ class DownloadManager private constructor(context: Context) {
    fun create(path: String, url: String): DownloadActionResponse {
       val existing = store.findByPath(path)
       if (existing != null) {
-         return DownloadActionResponse.withExpectedStatus(existing, DownloadStatus.Idle)
+         return DownloadActionResponse.withExpectedStatus(existing.toItem(), DownloadStatus.Idle)
       }
 
-      val item = DownloadItem(url = url, path = path)
-      store.append(item)
-      emitChanged(item)
+      val record = DownloadRecord(url = url, path = path)
+      store.append(record)
 
-      return DownloadActionResponse.new(item)
+      return DownloadActionResponse.new(emitChanged(record))
    }
 
    /**
@@ -122,19 +115,19 @@ class DownloadManager private constructor(context: Context) {
     */
    @Synchronized
    fun start(path: String): DownloadActionResponse {
-      val item = store.findByPath(path)
+      val record = store.findByPath(path)
          ?: throw DownloadException.NotFound(path)
 
-      if (item.status != DownloadStatus.Idle) {
-         return DownloadActionResponse.withExpectedStatus(item, DownloadStatus.InProgress)
+      if (record.status != DownloadStatus.Idle) {
+         return DownloadActionResponse.withExpectedStatus(record.toItem(), DownloadStatus.InProgress)
       }
 
-      val updated = item.withStatus(DownloadStatus.InProgress)
+      val updated = record.withStatus(DownloadStatus.InProgress)
       store.update(updated)
-      emitChanged(updated)
-      enqueueDownload(item)
+      val item = emitChanged(updated)
+      enqueueDownload(record)
 
-      return DownloadActionResponse.new(updated)
+      return DownloadActionResponse.new(item)
    }
 
    /**
@@ -146,19 +139,19 @@ class DownloadManager private constructor(context: Context) {
     */
    @Synchronized
    fun resume(path: String): DownloadActionResponse {
-      val item = store.findByPath(path)
+      val record = store.findByPath(path)
          ?: throw DownloadException.NotFound(path)
 
-      if (item.status != DownloadStatus.Paused) {
-         return DownloadActionResponse.withExpectedStatus(item, DownloadStatus.InProgress)
+      if (record.status != DownloadStatus.Paused) {
+         return DownloadActionResponse.withExpectedStatus(record.toItem(), DownloadStatus.InProgress)
       }
 
-      val updated = item.withStatus(DownloadStatus.InProgress)
+      val updated = record.withStatus(DownloadStatus.InProgress)
       store.update(updated)
-      emitChanged(updated)
-      enqueueDownload(item)
+      val item = emitChanged(updated)
+      enqueueDownload(record)
 
-      return DownloadActionResponse.new(updated)
+      return DownloadActionResponse.new(item)
    }
 
    /**
@@ -170,23 +163,24 @@ class DownloadManager private constructor(context: Context) {
     */
    @Synchronized
    fun pause(path: String): DownloadActionResponse {
-      val item = store.findByPath(path)
+      val record = store.findByPath(path)
          ?: throw DownloadException.NotFound(path)
 
-      if (item.status != DownloadStatus.InProgress) {
-         return DownloadActionResponse.withExpectedStatus(item, DownloadStatus.Paused)
+      if (record.status != DownloadStatus.InProgress) {
+         return DownloadActionResponse.withExpectedStatus(record.toItem(), DownloadStatus.Paused)
       }
 
       // Update status to paused — the DownloadWorker checks the store status
-      // on each progress tick and will stop reading when it sees Paused.
-      val updated = item.withStatus(DownloadStatus.Paused)
+      // on each progress tick and will stop reading when it sees Paused. This
+      // also persists the byte count from the last tick.
+      val updated = record.withStatus(DownloadStatus.Paused)
       store.update(updated)
-      emitChanged(updated)
+      val item = emitChanged(updated)
 
       // Also cancel the WorkManager work to stop the worker promptly.
       workManager.cancelUniqueWork(workName(path))
 
-      return DownloadActionResponse.new(updated)
+      return DownloadActionResponse.new(item)
    }
 
    /**
@@ -198,14 +192,14 @@ class DownloadManager private constructor(context: Context) {
     */
    @Synchronized
    fun cancel(path: String): DownloadActionResponse {
-      val item = store.findByPath(path)
+      val record = store.findByPath(path)
          ?: throw DownloadException.NotFound(path)
 
-      if (item.status != DownloadStatus.Idle &&
-         item.status != DownloadStatus.InProgress &&
-         item.status != DownloadStatus.Paused
+      if (record.status != DownloadStatus.Idle &&
+         record.status != DownloadStatus.InProgress &&
+         record.status != DownloadStatus.Paused
       ) {
-         return DownloadActionResponse.withExpectedStatus(item, DownloadStatus.Canceled)
+         return DownloadActionResponse.withExpectedStatus(record.toItem(), DownloadStatus.Canceled)
       }
 
       // Cancel the WorkManager work if running.
@@ -216,26 +210,29 @@ class DownloadManager private constructor(context: Context) {
       if (tempFile.exists()) tempFile.delete()
 
       // Remove from store and emit change.
-      val canceled = item.withStatus(DownloadStatus.Canceled)
-      store.remove(item)
-      emitChanged(canceled)
+      val canceled = record.withStatus(DownloadStatus.Canceled)
+      store.remove(record)
 
-      return DownloadActionResponse.new(canceled)
+      return DownloadActionResponse.new(emitChanged(canceled))
    }
 
    /**
-    * Emits a download item change event.
+    * Emits a download change event, derived from the persisted record.
     * Called by DownloadWorker to report progress and completion.
+    *
+    * Returns the emitted payload for reuse in a [DownloadActionResponse].
     */
-   internal fun emitChanged(item: DownloadItem) {
+   internal fun emitChanged(record: DownloadRecord): DownloadItem {
+      val item = record.toItem()
       _changed.tryEmit(item)
+      return item
    }
 
    /**
     * Enqueues a WorkManager work request for the download.
     * Uses unique work keyed by path to prevent duplicate workers.
     */
-   private fun enqueueDownload(item: DownloadItem) {
+   private fun enqueueDownload(record: DownloadRecord) {
       val constraints = Constraints.Builder()
          .setRequiredNetworkType(NetworkType.CONNECTED)
          .build()
@@ -244,15 +241,15 @@ class DownloadManager private constructor(context: Context) {
          .setConstraints(constraints)
          .setInputData(
             workDataOf(
-               DownloadWorker.KEY_URL to item.url,
-               DownloadWorker.KEY_PATH to item.path,
+               DownloadWorker.KEY_URL to record.url,
+               DownloadWorker.KEY_PATH to record.path,
             )
          )
          .addTag(WORK_TAG)
          .build()
 
       workManager.enqueueUniqueWork(
-         workName(item.path),
+         workName(record.path),
          ExistingWorkPolicy.REPLACE,
          workRequest,
       )
@@ -261,6 +258,36 @@ class DownloadManager private constructor(context: Context) {
    private fun workName(path: String): String = "$WORK_TAG:$path"
 
    companion object {
+      /**
+       * Decides what a record left `InProgress` with no worker behind it should
+       * become. Returns `null` when the record needs no change.
+       *
+       * A worker can stop without clearing the status — process death, WorkManager
+       * cancelling it, a transient error after its retries. The temp file is the
+       * only honest account of what survived: only bytes flushed to disk are
+       * resumable, whatever the last progress tick reported. With no temp file
+       * there is nothing to resume from, so the download restarts from scratch.
+       *
+       * Mirrors `Manager::revert_in_progress` in
+       * `crates/download-manager/src/manager.rs`, kept pure so it can be tested
+       * without WorkManager, as on iOS.
+       *
+       * @param record The record to reconcile.
+       * @param tempFileLength The temp file's length, or `null` when it is absent.
+       * @return The reverted record, or `null` when no change is needed.
+       */
+      internal fun revertInProgress(record: DownloadRecord, tempFileLength: Long?): DownloadRecord? {
+         if (record.status != DownloadStatus.InProgress) {
+            return null
+         }
+
+         return if (tempFileLength != null) {
+            record.withBytes(tempFileLength).withStatus(DownloadStatus.Paused)
+         } else {
+            record.withBytes(0L).withStatus(DownloadStatus.Idle)
+         }
+      }
+
       private const val TAG = "DownloadManager"
       private const val WORK_TAG = "download_manager"
 

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadRecord.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadRecord.kt
@@ -1,0 +1,67 @@
+package org.silvermine.downloadmanager
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Persisted download record, stored in `downloads.json`. Mirrors the Rust
+ * `DownloadRecord` in `crates/download-manager/src/models.rs`.
+ *
+ * Carries no `progress` — that is derived, and lives only on [DownloadItem],
+ * the type sent to the frontend.
+ */
+@Serializable
+internal data class DownloadRecord(
+   @SerialName("url")
+   val url: String,
+
+   @SerialName("path")
+   val path: String,
+
+   @SerialName("receivedBytes")
+   val receivedBytes: Long = 0L,
+
+   /** `null` when the server did not supply a content length. */
+   @SerialName("totalBytes")
+   val totalBytes: Long? = null,
+
+   @SerialName("status")
+   val status: DownloadStatus = DownloadStatus.Idle,
+) {
+   /**
+    * Sets the byte counts. A `null` total means "this response did not report one",
+    * not "there is none": a chunked resume cannot know a length an earlier response
+    * already established, so a null never erases a total the record holds. Pass a
+    * non-null total to widen or correct it.
+    */
+   fun withBytes(receivedBytes: Long, totalBytes: Long? = null): DownloadRecord =
+      copy(receivedBytes = receivedBytes, totalBytes = totalBytes ?: this.totalBytes)
+
+   fun withStatus(newStatus: DownloadStatus): DownloadRecord =
+      copy(status = newStatus)
+
+   /**
+    * Builds the public payload, computing `progress` from the byte counts.
+    *
+    * A completed download always reports 100%, even without a content length.
+    * In flight without one it reports 0%, since [receivedBytes] is then the
+    * only meaningful signal.
+    */
+   fun toItem(): DownloadItem {
+      val progress = when {
+         status == DownloadStatus.Completed -> 100.0
+         totalBytes != null && totalBytes > 0L ->
+            ((receivedBytes.toDouble() / totalBytes.toDouble()) * 100.0).coerceIn(0.0, 100.0)
+         else -> 0.0
+      }
+
+      return DownloadItem(
+         url = url,
+         path = path,
+         receivedBytes = receivedBytes,
+         totalBytes = totalBytes,
+         progress = progress,
+         status = status,
+      )
+   }
+}

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadStore.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadStore.kt
@@ -8,56 +8,77 @@ import kotlinx.serialization.json.Json
 import java.io.File
 
 /**
- * Thread-safe store for download items backed by an atomic JSON file.
+ * Thread-safe store for download records backed by an atomic JSON file.
  *
  * All public methods are synchronized to ensure consistency when accessed
  * from multiple threads (e.g. WorkManager workers and the main thread).
  * Mirrors the iOS DownloadStore actor pattern.
  */
 internal class DownloadStore(context: Context) {
-   private val json = Json { ignoreUnknownKeys = true }
    private val file = AtomicFile(File(context.filesDir, STORE_FILENAME))
-   private val downloads = mutableMapOf<String, DownloadItem>()
+   private val downloads = mutableMapOf<String, DownloadRecord>()
 
    init {
       load()
    }
 
    @Synchronized
-   fun list(): List<DownloadItem> = downloads.values.toList()
+   fun list(): List<DownloadRecord> = downloads.values.toList()
 
    @Synchronized
-   fun findByPath(path: String): DownloadItem? = downloads[path]
+   fun findByPath(path: String): DownloadRecord? = downloads[path]
 
    @Synchronized
-   fun append(item: DownloadItem) {
-      downloads[item.path] = item
+   fun append(record: DownloadRecord) {
+      downloads[record.path] = record
       save()
    }
 
    @Synchronized
-   fun update(item: DownloadItem, persist: Boolean = true) {
-      if (downloads.containsKey(item.path)) {
-         downloads[item.path] = item
+   fun update(record: DownloadRecord, persist: Boolean = true) {
+      if (downloads.containsKey(record.path)) {
+         downloads[record.path] = record
       }
       if (persist) {
          save()
       }
    }
 
+   /**
+    * Applies several record updates with a single write.
+    *
+    * Reconciliation can revert many records at once; one write per record would
+    * rewrite the whole file that many times.
+    *
+    * @param records The records to update. Unknown paths are ignored.
+    */
    @Synchronized
-   fun remove(item: DownloadItem) {
-      downloads.remove(item.path)
+   fun update(records: List<DownloadRecord>) {
+      if (records.isEmpty()) {
+         return
+      }
+
+      for (record in records) {
+         if (downloads.containsKey(record.path)) {
+            downloads[record.path] = record
+         }
+      }
+
+      save()
+   }
+
+   @Synchronized
+   fun remove(record: DownloadRecord) {
+      downloads.remove(record.path)
       save()
    }
 
    private fun load() {
       try {
-         val bytes = file.readFully()
-         val items: List<DownloadItem> = json.decodeFromString(String(bytes))
+         val records = decodeRecords(String(file.readFully()))
          downloads.clear()
-         for (item in items) {
-            downloads[item.path] = item
+         for (record in records) {
+            downloads[record.path] = record
          }
       } catch (e: Exception) {
          Log.e(TAG, "Failed to load download store: ${e.message}")
@@ -65,8 +86,7 @@ internal class DownloadStore(context: Context) {
    }
 
    private fun save() {
-      val items = downloads.values.toList()
-      val bytes = json.encodeToString(items).toByteArray()
+      val bytes = encodeRecords(downloads.values.toList()).toByteArray()
       val stream = file.startWrite()
       try {
          stream.write(bytes)
@@ -80,5 +100,29 @@ internal class DownloadStore(context: Context) {
    companion object {
       private const val TAG = "DownloadStore"
       private const val STORE_FILENAME = "downloads.json"
+
+      private val json = Json { ignoreUnknownKeys = true }
+
+      /**
+       * Decodes persisted records.
+       *
+       * Note that one malformed element fails the whole array, discarding every
+       * other download in the file. Making that per-record is tracked in #64.
+       *
+       * Extracted from [load] so it can be unit-tested, and deliberately free of
+       * logging to keep it so: `android.util.Log` is a throwing stub off-device.
+       *
+       * @param text The persisted store's contents.
+       * @return The decoded records.
+       */
+      internal fun decodeRecords(text: String): List<DownloadRecord> = json.decodeFromString(text)
+
+      /**
+       * Encodes records for persistence.
+       *
+       * @param records The records to encode.
+       * @return The JSON text to persist.
+       */
+      internal fun encodeRecords(records: List<DownloadRecord>): String = json.encodeToString(records)
    }
 }

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
@@ -28,7 +28,7 @@ import javax.net.ssl.SSLException
  * Mirrors the Rust downloader.rs pattern:
  * - Supports resume via Range headers
  * - Writes to a temp file (.download suffix), renames on completion
- * - Throttles progress updates to 1% increments
+ * - Throttles progress updates via [ProgressTracker]
  * - Checks store status each progress tick to detect pause/cancel
  * - Runs as a foreground service with a notification
  */
@@ -50,6 +50,11 @@ internal class DownloadWorker(
       } catch (e: Exception) {
          Log.w(TAG, "Failed to set foreground info: ${e.message}")
       }
+
+      // Byte counts outlive the response scope so the completion block below can
+      // report what the progress loop tracked.
+      var finalReceivedBytes = 0L
+      var finalTotalBytes: Long? = null
 
       try {
          // Check the size of the already downloaded part, if any.
@@ -84,8 +89,11 @@ internal class DownloadWorker(
                ?: return handleError(manager, store, path, tempFile, "Empty response body")
 
             // Get the total size of the file from headers (if available).
+            // OkHttp reports -1 when unknown, which stays null rather than
+            // collapsing to a bogus zero total.
             val contentLength = body.contentLength()
-            val totalSize = if (contentLength > 0) contentLength + downloadedSize else 0L
+            val contentLengthSum = contentLength + downloadedSize
+            val totalSize = if (contentLength > 0 && contentLengthSum > 0) contentLengthSum else null
 
             // Ensure the output folder exists.
             tempFile.parentFile?.let { parent ->
@@ -94,16 +102,25 @@ internal class DownloadWorker(
 
             // Open the temp file in append mode (or truncate if restarting from zero).
             val append = downloadedSize > 0
-            var downloaded = downloadedSize
-            var lastEmittedProgress = 0.0
-            var lastEmittedBytes = downloadedSize
 
-            // Update status to in-progress.
-            store.findByPath(path)?.let { item ->
-               val updated = item.withStatus(DownloadStatus.InProgress)
-               store.update(updated)
-               manager.emitChanged(updated)
+            // The temp file is the authority: a server that ignores the Range header
+            // restarts from zero and the record must follow it down. Synchronized
+            // against pause/cancel; a pause landing first is undone by isStopped below.
+            var effectiveTotal = totalSize
+
+            synchronized(manager) {
+               store.findByPath(path)?.let { record ->
+                  val updated = record.withBytes(downloadedSize, totalSize)
+
+                  effectiveTotal = updated.totalBytes
+                  store.update(updated.withStatus(DownloadStatus.InProgress))
+               }
             }
+
+            // Falls back to the record's known total: without it an unknown content
+            // length drops the transfer onto the coarse byte cadence and contradicts
+            // the indeterminate flag, which keys off the coalesced emitted total.
+            val progressTracker = ProgressTracker(downloadedSize, effectiveTotal)
 
             FileOutputStream(tempFile, append).use { output ->
                val buffer = ByteArray(BUFFER_SIZE)
@@ -113,6 +130,7 @@ internal class DownloadWorker(
                   // Check if the worker has been stopped (canceled externally).
                   if (isStopped) {
                      source.close()
+                     revertInProgressRecord(manager, store, path)
                      dismissNotification()
                      return Result.success()
                   }
@@ -121,35 +139,37 @@ internal class DownloadWorker(
                   if (bytesRead == -1) break
 
                   output.write(buffer, 0, bytesRead)
-                  downloaded += bytesRead
+                  progressTracker.advance(bytesRead.toLong())
 
-                  val progress = if (totalSize > 0) {
-                     (downloaded.toDouble() / totalSize.toDouble()) * 100.0
-                  } else {
-                     0.0
-                  }
+                  if (!progressTracker.shouldEmit()) continue
 
-                  // Throttle progress updates:
-                  // - Known size: emit when progress increases by at least 1%.
-                  // - Unknown size: emit every BYTES_THRESHOLD bytes.
-                  val shouldThrottle = if (totalSize > 0) {
-                     progress < 100.0 && progress - lastEmittedProgress <= PROGRESS_THRESHOLD
-                  } else {
-                     downloaded - lastEmittedBytes < BYTES_THRESHOLD
-                  }
-                  if (shouldThrottle) continue
+                  progressTracker.markEmitted()
 
-                  lastEmittedProgress = progress
-                  lastEmittedBytes = downloaded
-                  val currentItem = store.findByPath(path) ?: break
+                  // Read and write as one step: pause() holds this same monitor, and a
+                  // pause landing between them is overwritten back to InProgress. Since
+                  // cancelUniqueWork() is async, a resume in that window then reports
+                  // success and enqueues nothing. Emit and notify outside the lock.
+                  val currentRecord = synchronized(manager) {
+                     val record = store.findByPath(path)
 
-                  when (currentItem.status) {
+                     if (record != null && record.status == DownloadStatus.InProgress && !progressTracker.isComplete()) {
+                        val updated = record
+                           .withBytes(progressTracker.receivedBytes, totalSize)
+                           .withStatus(DownloadStatus.InProgress)
+
+                        store.update(updated, persist = false)
+                        updated
+                     } else {
+                        record
+                     }
+                  } ?: break
+
+                  when (currentRecord.status) {
                      DownloadStatus.InProgress -> {
-                        if (progress < 100.0) {
-                           val updated = currentItem.withProgress(progress)
-                           store.update(updated, persist = false)
-                           manager.emitChanged(updated)
-                           updateNotificationProgress(path, progress.toInt())
+                        if (!progressTracker.isComplete()) {
+                           // Emit the record just written.
+                           val item = manager.emitChanged(currentRecord)
+                           updateNotificationProgress(path, item.progress.toInt(), indeterminate = item.totalBytes == null)
                         }
                         // Completion is handled after the loop exits naturally.
                      }
@@ -168,15 +188,18 @@ internal class DownloadWorker(
                   }
                }
             }
+
+            finalReceivedBytes = progressTracker.receivedBytes
+            finalTotalBytes = totalSize
          }
 
          // Download completed — rename temp file to final path and update store.
          // Synchronized on manager to prevent interleaving with cancel/pause,
          // mirroring the iOS actor serialization pattern.
          var renameFailed = false
-         synchronized(manager) {
-            val currentItem = store.findByPath(path)
-            if (currentItem != null && currentItem.status == DownloadStatus.InProgress) {
+         synchronized<Unit>(manager) {
+            val currentRecord = store.findByPath(path)
+            if (currentRecord != null && currentRecord.status == DownloadStatus.InProgress) {
                val finalFile = File(path)
                finalFile.parentFile?.let { parent ->
                   if (!parent.exists()) parent.mkdirs()
@@ -187,8 +210,10 @@ internal class DownloadWorker(
                if (!tempFile.renameTo(finalFile)) {
                   renameFailed = true
                } else {
-                  val completed = currentItem.withStatus(DownloadStatus.Completed)
-                  store.remove(currentItem)
+                  val completed = currentRecord
+                     .withBytes(finalReceivedBytes, finalTotalBytes)
+                     .withStatus(DownloadStatus.Completed)
+                  store.remove(currentRecord)
                   manager.emitChanged(completed)
                }
             } else {
@@ -221,6 +246,31 @@ internal class DownloadWorker(
    }
 
    /**
+    * Reverts a record still marked InProgress when this worker stops early —
+    * either stopped externally, or out of retries on a transient error.
+    *
+    * A pause cancels the WorkManager work and sets the record to Paused, but the
+    * worker may already have written InProgress back before observing isStopped.
+    * Without this the record would stay InProgress with no worker behind it until
+    * the next reconcileStoreOnInit().
+    *
+    * [DownloadManager.revertInProgress] decides the resulting status, so this and
+    * reconciliation cannot drift apart. The temp file is left in place, and a
+    * record that is no longer InProgress — a pause that landed first — is left
+    * alone rather than overwritten.
+    */
+   private fun revertInProgressRecord(manager: DownloadManager, store: DownloadStore, path: String) {
+      // Synchronized on manager to prevent interleaving with cancel/pause.
+      synchronized(manager) {
+         val record = store.findByPath(path) ?: return
+         val reverted = DownloadManager.revertInProgress(record, tempFileLength(path)) ?: return
+
+         store.update(reverted)
+         manager.emitChanged(reverted)
+      }
+   }
+
+   /**
     * Handles permanent failures (HTTP errors, rename failures, DNS/TLS errors).
     * Deletes the temp file, cancels the download, and removes it from the store.
     */
@@ -230,9 +280,9 @@ internal class DownloadWorker(
       // Synchronized on manager to prevent interleaving with cancel/pause.
       synchronized(manager) {
          if (tempFile.exists()) tempFile.delete()
-         store.findByPath(path)?.let { item ->
-            val canceled = item.withStatus(DownloadStatus.Canceled)
-            store.remove(item)
+         store.findByPath(path)?.let { record ->
+            val canceled = record.withStatus(DownloadStatus.Canceled)
+            store.remove(record)
             manager.emitChanged(canceled)
          }
       }
@@ -250,14 +300,7 @@ internal class DownloadWorker(
    private fun handleTransientError(manager: DownloadManager, store: DownloadStore, path: String, message: String): Result {
       Log.w(TAG, "Download failed (transient) for $path: $message")
 
-      // Synchronized on manager to prevent interleaving with cancel/pause.
-      synchronized(manager) {
-         store.findByPath(path)?.let { item ->
-            val paused = item.withStatus(DownloadStatus.Paused)
-            store.update(paused)
-            manager.emitChanged(paused)
-         }
-      }
+      revertInProgressRecord(manager, store, path)
 
       dismissNotification()
       return Result.failure()
@@ -297,8 +340,8 @@ internal class DownloadWorker(
       }
    }
 
-   private fun updateNotificationProgress(path: String, progress: Int) {
-      val notification = buildNotification(File(path).name, progress, indeterminate = false)
+   private fun updateNotificationProgress(path: String, progress: Int, indeterminate: Boolean) {
+      val notification = buildNotification(File(path).name, progress, indeterminate)
       val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
       notificationManager.notify(notificationID(), notification)
    }
@@ -348,10 +391,19 @@ internal class DownloadWorker(
       internal const val TAG = "DownloadWorker"
       internal const val DOWNLOAD_SUFFIX = ".download"
       private const val BUFFER_SIZE = 64 * 1024
-      private const val PROGRESS_THRESHOLD = 1.0
-      private const val BYTES_THRESHOLD = 1024L * 1024L
       private const val MAX_RETRIES = 3
       private const val NOTIFICATION_CHANNEL_ID = "download_manager_channel"
+
+      /**
+       * The length of a download's temp file, or `null` when it is absent.
+       *
+       * @param path The download path.
+       * @return The temp file's length, or `null` when there is no temp file.
+       */
+      internal fun tempFileLength(path: String): Long? {
+         val tempFile = File("$path$DOWNLOAD_SUFFIX")
+         return if (tempFile.exists()) tempFile.length() else null
+      }
 
       private fun isTransient(e: IOException): Boolean = when (e) {
          is UnknownHostException -> false  // DNS resolution failed

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/ProgressTracker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/ProgressTracker.kt
@@ -1,0 +1,54 @@
+package org.silvermine.downloadmanager
+
+/**
+ * Decides when a progress update should be emitted: on every change of integer
+ * percent when [totalBytes] is known and positive, otherwise every
+ * [BYTES_THRESHOLD] bytes.
+ *
+ * Tracks [receivedBytes] internally, so the download loop only calls [advance]
+ * with each chunk size and checks [shouldEmit]. Mirrors the Rust
+ * `ProgressTracker` in `crates/download-manager/src/downloader.rs`.
+ */
+internal class ProgressTracker(receivedBytes: Long, private val totalBytes: Long?) {
+   var receivedBytes: Long = receivedBytes
+      private set
+
+   private var lastEmittedPercent: Long = percent(receivedBytes, totalBytes)
+   private var lastEmittedBytes: Long = receivedBytes
+
+   fun advance(bytesWritten: Long) {
+      receivedBytes += bytesWritten
+   }
+
+   fun shouldEmit(): Boolean {
+      if (totalBytes == null || totalBytes <= 0L) {
+         return (receivedBytes - lastEmittedBytes) >= BYTES_THRESHOLD
+      }
+
+      // `percent >= 100` never emits — the call site suppresses it. Kept because a
+      // true still drives the per-chunk store poll that detects pause and cancel.
+      val percent = percent(receivedBytes, totalBytes)
+      return (percent >= 100L || percent > lastEmittedPercent)
+   }
+
+   // The total is guarded as positive, not merely non-null: a wrapped Content-Length
+   // sum would otherwise make every download read as complete from its first byte,
+   // suppressing the emissions the loop gates behind this.
+   fun isComplete(): Boolean = (totalBytes != null && totalBytes > 0L && receivedBytes >= totalBytes)
+
+   fun markEmitted() {
+      lastEmittedPercent = percent(receivedBytes, totalBytes)
+      lastEmittedBytes = receivedBytes
+   }
+
+   companion object {
+      const val BYTES_THRESHOLD = 1024L * 1024L
+
+      private fun percent(bytes: Long, total: Long?): Long {
+         if (total == null || total <= 0L) {
+            return 0L
+         }
+         return ((bytes * 100L) / total)
+      }
+   }
+}

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
@@ -1,0 +1,61 @@
+package org.silvermine.downloadmanager
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DownloadManagerTest {
+
+   private fun inProgressRecord(): DownloadRecord = DownloadRecord(
+      url = "http://example.com/file.mp4",
+      path = "/tmp/file.mp4",
+      receivedBytes = 500L,
+      totalBytes = 1000L,
+      status = DownloadStatus.InProgress,
+   )
+
+   // -- Reconciliation --
+
+   @Test
+   fun `record with a temp file reverts to paused at the flushed length`() {
+      val reverted = DownloadManager.revertInProgress(inProgressRecord(), tempFileLength = 480L)
+
+      assertEquals(DownloadStatus.Paused, reverted?.status)
+      // Only bytes flushed to disk are resumable, so the temp file's length wins
+      // over the 500 the last progress tick reported.
+      assertEquals(480L, reverted?.receivedBytes)
+      assertEquals(1000L, reverted?.totalBytes)
+   }
+
+   @Test
+   fun `record without a temp file reverts to idle at zero`() {
+      val reverted = DownloadManager.revertInProgress(inProgressRecord(), tempFileLength = null)
+
+      assertEquals(DownloadStatus.Idle, reverted?.status)
+      // Nothing to resume from, so the download restarts from scratch.
+      assertEquals(0L, reverted?.receivedBytes)
+      // The total came from headers and is still true of the remote file.
+      assertEquals(1000L, reverted?.totalBytes)
+   }
+
+   @Test
+   fun `an empty temp file still reverts to paused`() {
+      val reverted = DownloadManager.revertInProgress(inProgressRecord(), tempFileLength = 0L)
+
+      assertEquals(DownloadStatus.Paused, reverted?.status)
+      assertEquals(0L, reverted?.receivedBytes)
+   }
+
+   @Test
+   fun `records that are not in progress are left alone`() {
+      // Derived from the enum so a status added later is covered automatically.
+      val statuses = DownloadStatus.entries.filter { it != DownloadStatus.InProgress }
+
+      for (status in statuses) {
+         val record = inProgressRecord().withStatus(status)
+
+         assertNull("$status should not be reverted", DownloadManager.revertInProgress(record, 480L))
+         assertNull("$status should not be reverted", DownloadManager.revertInProgress(record, null))
+      }
+   }
+}

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadRecordTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadRecordTest.kt
@@ -1,0 +1,189 @@
+package org.silvermine.downloadmanager
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadRecordTest {
+
+   private fun sampleRecord(): DownloadRecord = DownloadRecord(
+      url = "http://example.com/file.mp4",
+      path = "/tmp/file.mp4",
+      receivedBytes = 0L,
+      totalBytes = null,
+      status = DownloadStatus.Idle,
+   )
+
+   private val json = Json { encodeDefaults = true }
+
+   // The emit-only DownloadItem must spell out every key regardless of the Json
+   // config, so its serialization is asserted through a default encoder.
+   private val defaultJson = Json
+
+   // -- Mutation --
+
+   @Test
+   fun `withBytes sets byte counts and leaves the rest alone`() {
+      val record = sampleRecord()
+      val updated = record.withBytes(500L, 1000L)
+
+      assertEquals(500L, updated.receivedBytes)
+      assertEquals(1000L, updated.totalBytes)
+      assertEquals(DownloadStatus.Idle, updated.status)
+      assertEquals(record.url, updated.url)
+      assertEquals(record.path, updated.path)
+   }
+
+   @Test
+   fun `withStatus preserves byte counts`() {
+      val record = sampleRecord().withBytes(500L, 1000L)
+
+      val paused = record.withStatus(DownloadStatus.Paused)
+      assertEquals(500L, paused.receivedBytes)
+      assertEquals(1000L, paused.totalBytes)
+      assertEquals(DownloadStatus.Paused, paused.status)
+
+      // Status transitions preserve the factual byte counts, including completion.
+      val completed = record.withStatus(DownloadStatus.Completed)
+      assertEquals(500L, completed.receivedBytes)
+      assertEquals(1000L, completed.totalBytes)
+      assertEquals(DownloadStatus.Completed, completed.status)
+      assertEquals(100.0, completed.toItem().progress, 0.0)
+   }
+
+   @Test
+   fun `withStatus completed with unknown size preserves receivedBytes`() {
+      val completed = sampleRecord()
+         .withBytes(5000L, null)
+         .withStatus(DownloadStatus.Completed)
+
+      assertEquals(5000L, completed.receivedBytes)
+      assertNull(completed.totalBytes)
+   }
+
+   // -- Progress derivation --
+
+   @Test
+   fun `toItem with known size`() {
+      val item = sampleRecord().withBytes(500L, 1000L).toItem()
+
+      assertEquals(50.0, item.progress, 0.0)
+      assertEquals(500L, item.receivedBytes)
+      assertEquals(1000L, item.totalBytes)
+   }
+
+   @Test
+   fun `toItem clamps progress to 100 percent`() {
+      val item = sampleRecord().withBytes(1500L, 1000L).toItem()
+
+      assertEquals(100.0, item.progress, 0.0)
+   }
+
+   @Test
+   fun `toItem with unknown size`() {
+      val record = sampleRecord()
+      assertEquals(0.0, record.toItem().progress, 0.0)
+
+      // Completed with unknown size still reports 100%.
+      val completed = record.withStatus(DownloadStatus.Completed)
+      assertEquals(100.0, completed.toItem().progress, 0.0)
+   }
+
+   @Test
+   fun `toItem with zero total does not divide by zero`() {
+      val item = sampleRecord().withBytes(0L, 0L).toItem()
+
+      assertEquals(0.0, item.progress, 0.0)
+   }
+
+   // -- Serialization --
+
+   @Test
+   fun `item serializes totalBytes as explicit null`() {
+      // The key is always present, so the payload matches the frontend contract
+      // without relying on the TypeScript layer to coalesce a missing key.
+      val encoded = defaultJson.encodeToString(DownloadItem.serializer(), sampleRecord().toItem())
+
+      assertTrue(encoded.contains("\"totalBytes\":null"))
+   }
+
+   @Test
+   fun `item serializes byte fields`() {
+      val encoded = defaultJson.encodeToString(
+         DownloadItem.serializer(),
+         sampleRecord().withBytes(500L, 1000L).toItem(),
+      )
+
+      assertTrue(encoded.contains("\"receivedBytes\":500"))
+      assertTrue(encoded.contains("\"totalBytes\":1000"))
+      assertTrue(encoded.contains("\"progress\":50.0"))
+      assertTrue(encoded.contains("\"status\":\"idle\""))
+   }
+
+   @Test
+   fun `record does not persist progress`() {
+      val encoded = json.encodeToString(
+         DownloadRecord.serializer(),
+         sampleRecord().withBytes(500L, 1000L),
+      )
+
+      assertFalse(encoded.contains("progress"))
+   }
+
+   @Test
+   fun `record decodes persisted wire format`() {
+      // A literal payload, not a round trip, which would pass even if the
+      // field names drifted on both sides together.
+      val encoded = """
+         {"url":"http://example.com/f.mp4","path":"/tmp/f.mp4",
+         "receivedBytes":500,"totalBytes":1000,"status":"paused"}
+      """.trimIndent()
+
+      val record = json.decodeFromString(DownloadRecord.serializer(), encoded)
+
+      assertEquals(500L, record.receivedBytes)
+      assertEquals(1000L, record.totalBytes)
+      assertEquals(DownloadStatus.Paused, record.status)
+      // progress is derived via toItem(), not stored.
+      assertEquals(50.0, record.toItem().progress, 0.0)
+   }
+
+   @Test
+   fun `record round trips through JSON`() {
+      val record = sampleRecord().withBytes(500L, 1000L).withStatus(DownloadStatus.Paused)
+      val decoded = json.decodeFromString(
+         DownloadRecord.serializer(),
+         json.encodeToString(DownloadRecord.serializer(), record),
+      )
+
+      assertEquals(500L, decoded.receivedBytes)
+      assertEquals(1000L, decoded.totalBytes)
+      assertEquals(DownloadStatus.Paused, decoded.status)
+      // progress is derived via toItem(), not stored.
+      assertEquals(50.0, decoded.toItem().progress, 0.0)
+   }
+
+   // -- Action response --
+
+   @Test
+   fun `action response reports expected status`() {
+      val item = sampleRecord().toItem()
+
+      // new() reports the status as expected.
+      val response = DownloadActionResponse.new(item)
+      assertTrue(response.isExpectedStatus)
+      assertEquals(DownloadStatus.Idle, response.expectedStatus)
+
+      // A matching expected status is still expected.
+      val matching = DownloadActionResponse.withExpectedStatus(item, DownloadStatus.Idle)
+      assertTrue(matching.isExpectedStatus)
+
+      // A mismatched expected status is not.
+      val mismatched = DownloadActionResponse.withExpectedStatus(item, DownloadStatus.InProgress)
+      assertFalse(mismatched.isExpectedStatus)
+      assertEquals(DownloadStatus.InProgress, mismatched.expectedStatus)
+   }
+}

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadStoreTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadStoreTest.kt
@@ -1,0 +1,130 @@
+package org.silvermine.downloadmanager
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+
+/**
+ * Covers the store's decode and encode, which is where a malformed file decides
+ * whether one record or every record is lost.
+ *
+ * The `AtomicFile` wiring around them needs an Android runtime, so it is not
+ * exercised here — `android.util.AtomicFile` and `android.util.Log` are throwing
+ * stubs in a JVM unit test.
+ */
+class DownloadStoreTest {
+
+   private fun sampleRecord(path: String, receivedBytes: Long = 0L): DownloadRecord = DownloadRecord(
+      url = "http://example.com/$path",
+      path = "/tmp/$path",
+      receivedBytes = receivedBytes,
+      totalBytes = 1000L,
+      status = DownloadStatus.Paused,
+   )
+
+   // -- Decoding --
+
+   @Test
+   fun `decodes persisted records`() {
+      val decoded = DownloadStore.decodeRecords(
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","receivedBytes":500,"totalBytes":1000,"status":"paused"}]"""
+      )
+
+      assertEquals(1, decoded.size)
+      assertEquals(500L, decoded.first().receivedBytes)
+      assertEquals(1000L, decoded.first().totalBytes)
+      assertEquals(DownloadStatus.Paused, decoded.first().status)
+   }
+
+   @Test
+   fun `one unreadable record discards the whole store`() {
+      // Pins today's behaviour, which is not the behaviour we want: the array is
+      // decoded in one call, so the middle element takes both good records with it
+      // and load() falls back to an empty store. Invert this test when per-record
+      // decoding lands (#64).
+      //
+      // Scoped to the decode call so the inverted test fails for a known reason.
+      // Type only: the message wording is kotlinx's, not a contract.
+      assertThrows(SerializationException::class.java) {
+         DownloadStore.decodeRecords(
+            """
+            [{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","receivedBytes":1,"status":"paused"},
+             {"url":"http://example.com/b.mp4","status":"paused"},
+             {"url":"http://example.com/c.mp4","path":"/tmp/c.mp4","receivedBytes":3,"status":"idle"}]
+            """.trimIndent()
+         )
+      }
+   }
+
+   @Test
+   fun `a record of the wrong shape fails the decode`() {
+      assertThrows(SerializationException::class.java) {
+         DownloadStore.decodeRecords("""["not an object"]""")
+      }
+   }
+
+   @Test
+   fun `unknown keys are ignored`() {
+      // The store's Json is configured with ignoreUnknownKeys, so a field added by
+      // a later version does not cost the record.
+      val decoded = DownloadStore.decodeRecords(
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","receivedBytes":7,"status":"idle","somethingNew":42}]"""
+      )
+
+      assertEquals(7L, decoded.first().receivedBytes)
+   }
+
+   @Test
+   fun `absent byte fields fall back to their defaults`() {
+      val decoded = DownloadStore.decodeRecords(
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","status":"idle"}]"""
+      )
+
+      assertEquals(0L, decoded.first().receivedBytes)
+      assertNull(decoded.first().totalBytes)
+   }
+
+   @Test
+   fun `an empty array decodes to nothing`() {
+      val decoded = DownloadStore.decodeRecords("[]")
+
+      assertEquals(0, decoded.size)
+   }
+
+   @Test
+   fun `text that is not a json array is rejected`() {
+      // load() catches these and leaves the store empty rather than half-built.
+      for (text in listOf("this is not json", """{"url":"http://example.com/a.mp4"}""", "")) {
+         assertThrows(SerializationException::class.java) { DownloadStore.decodeRecords(text) }
+      }
+   }
+
+   // -- Round trip --
+
+   @Test
+   fun `encoded records decode back unchanged`() {
+      val records = listOf(sampleRecord("a.mp4", 10L), sampleRecord("b.mp4", 20L))
+
+      val decoded = DownloadStore.decodeRecords(DownloadStore.encodeRecords(records))
+
+      assertEquals(records, decoded)
+   }
+
+   @Test
+   fun `a record of every default survives the round trip`() {
+      // The store's Json leaves encodeDefaults off, so a default-valued record
+      // persists as url and path alone — the shape production actually writes.
+      val record = DownloadRecord(url = "http://example.com/a.mp4", path = "/tmp/a.mp4")
+
+      val encoded = DownloadStore.encodeRecords(listOf(record))
+      val decoded = DownloadStore.decodeRecords(encoded)
+
+      assertFalse(encoded.contains("receivedBytes"))
+      assertEquals(listOf(record), decoded)
+      assertEquals(0L, decoded.first().receivedBytes)
+      assertNull(decoded.first().totalBytes)
+   }
+}

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/ProgressTrackerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/ProgressTrackerTest.kt
@@ -1,0 +1,116 @@
+package org.silvermine.downloadmanager
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProgressTrackerTest {
+
+   // -- Known size --
+
+   @Test
+   fun `emits on integer percent change`() {
+      val tracker = ProgressTracker(0L, 1000L)
+
+      // 0.9% — still rounds to percent 0, which is what was last emitted.
+      tracker.advance(9L)
+      assertFalse(tracker.shouldEmit())
+
+      // 1.0% — crosses into percent 1.
+      tracker.advance(1L)
+      assertTrue(tracker.shouldEmit())
+   }
+
+   @Test
+   fun `markEmitted advances the baseline`() {
+      val tracker = ProgressTracker(0L, 1000L)
+
+      tracker.advance(10L)
+      assertTrue(tracker.shouldEmit())
+      tracker.markEmitted()
+
+      // Same percent as the last emission, so nothing new to report.
+      assertFalse(tracker.shouldEmit())
+
+      tracker.advance(10L)
+      assertTrue(tracker.shouldEmit())
+   }
+
+   @Test
+   fun `always emits at one hundred percent`() {
+      val tracker = ProgressTracker(0L, 1000L)
+
+      tracker.advance(1000L)
+      assertTrue(tracker.shouldEmit())
+      tracker.markEmitted()
+
+      // Still emits past 100% rather than going quiet.
+      assertTrue(tracker.shouldEmit())
+   }
+
+   @Test
+   fun `resuming treats initial bytes as already emitted`() {
+      // A resumed download must not re-emit the count it started from.
+      val tracker = ProgressTracker(500L, 1000L)
+      assertFalse(tracker.shouldEmit())
+
+      tracker.advance(9L)
+      assertFalse(tracker.shouldEmit())
+
+      tracker.advance(1L)
+      assertTrue(tracker.shouldEmit())
+   }
+
+   @Test
+   fun `isComplete with known size`() {
+      val tracker = ProgressTracker(0L, 1000L)
+      assertFalse(tracker.isComplete())
+
+      tracker.advance(999L)
+      assertFalse(tracker.isComplete())
+
+      tracker.advance(1L)
+      assertTrue(tracker.isComplete())
+   }
+
+   @Test
+   fun `zero total falls back to the byte threshold`() {
+      // A zero content length must not divide by zero; treat it as unknown.
+      val tracker = ProgressTracker(0L, 0L)
+      assertFalse(tracker.shouldEmit())
+
+      tracker.advance(ProgressTracker.BYTES_THRESHOLD)
+      assertTrue(tracker.shouldEmit())
+
+      // A zero total would otherwise read as complete from the first byte.
+      assertFalse(tracker.isComplete())
+   }
+
+   // -- Unknown size --
+
+   @Test
+   fun `emits every threshold when size is unknown`() {
+      val tracker = ProgressTracker(0L, null)
+
+      tracker.advance(ProgressTracker.BYTES_THRESHOLD - 1L)
+      assertFalse(tracker.shouldEmit())
+
+      tracker.advance(1L)
+      assertTrue(tracker.shouldEmit())
+      tracker.markEmitted()
+
+      assertFalse(tracker.shouldEmit())
+
+      tracker.advance(ProgressTracker.BYTES_THRESHOLD)
+      assertTrue(tracker.shouldEmit())
+   }
+
+   @Test
+   fun `is never complete when size is unknown`() {
+      // Unknown-size completion is signalled by the stream ending.
+      val tracker = ProgressTracker(0L, null)
+      tracker.advance(10L * ProgressTracker.BYTES_THRESHOLD)
+
+      assertFalse(tracker.isComplete())
+   }
+}

--- a/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
+++ b/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.json.JSONArray
+import java.io.File
 
 @InvokeArg
 class PathArgs {
@@ -44,7 +45,11 @@ class DownloadPlugin(activity: Activity) : Plugin(activity) {
          downloadManager.changed.collect { item ->
             try {
                trigger("changed", JSObject(json.encodeToString(item)))
-               Log.d(TAG, "[${item.path}] ${item.status} - ${"%.0f".format(item.progress)}%")
+               Log.d(
+                  TAG,
+                  "[${File(item.path).name}] ${item.status} - ${"%.0f".format(item.progress)}%" +
+                     " (${item.receivedBytes}/${item.totalBytes ?: "unknown"} bytes)",
+               )
             } catch (e: Exception) {
                Log.e(TAG, "Failed to emit changed event: ${e.message}")
             }

--- a/examples/tauri-app/src/DownloadView.vue
+++ b/examples/tauri-app/src/DownloadView.vue
@@ -16,6 +16,7 @@
       </div>
       <div class="item-info">
          <p class="state-text">State: {{ currentDownload.status }}</p>
+         <p class="byte-text">{{ byteCount }}</p>
          <p class="progress-text">{{ Math.round(currentDownload.progress) }}%</p>
       </div>
    </div>
@@ -43,6 +44,30 @@ const props = defineProps<{ download: DownloadWithAnyStatus, url?: string }>(),
       canCancel = computed(() => { return hasAction(currentDownload.value, DownloadAction.Cancel); }),
       canPause = computed(() => { return hasAction(currentDownload.value, DownloadAction.Pause); }),
       canResume = computed(() => { return hasAction(currentDownload.value, DownloadAction.Resume); });
+
+const BYTE_UNITS = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
+
+function formatBytes(bytes: number): string {
+   let value = bytes,
+       unitIndex = 0;
+
+   while (value >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+      value = value / 1024;
+      unitIndex = unitIndex + 1;
+   }
+
+   return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${BYTE_UNITS[unitIndex]}`;
+}
+
+// A server that omits the content length leaves totalBytes null, so the total
+// is not always known even while bytes are arriving. A strict null check is safe:
+// attachDownload() normalizes an absent key to null before it reaches here.
+const byteCount = computed<string>(() => {
+   const { receivedBytes, totalBytes } = currentDownload.value,
+         total = totalBytes === null ? 'unknown' : formatBytes(totalBytes);
+
+   return `${formatBytes(receivedBytes)} / ${total}`;
+});
 
 
 let unlisten: UnlistenFn | undefined;
@@ -198,6 +223,13 @@ async function doAction<A extends NoArgAction>(action: A): Promise<void> {
     font-size: 14px;
     color: #555;
     margin: 0;
+  }
+
+  .byte-text {
+    font-size: 14px;
+    color: #555;
+    margin: 0;
+    white-space: nowrap;
   }
 
   .progress-bar {

--- a/guest-js/mocks.test.ts
+++ b/guest-js/mocks.test.ts
@@ -283,7 +283,7 @@ describe('mockDownloadPlugin', () => {
 
       const expectedStatus = getExpectedStatus(action);
 
-      const isAllowed = allowedActions[status].includes(action);
+      const isAllowed = (allowedActions[status] as readonly DownloadAction[]).includes(action);
 
       const expectedResultStatus = isAllowed ? expectedStatus : status;
 

--- a/ios/DownloadManagerExample/DownloadManagerExample/DownloadsView.swift
+++ b/ios/DownloadManagerExample/DownloadManagerExample/DownloadsView.swift
@@ -64,7 +64,7 @@ struct DownloadsView: View {
          .task {
             downloads = await manager.list()
             for await download in manager.changed {
-               print("[\(download.path)] \(download.status) - \(String(format: "%.0f", download.progress))%")
+               print("[\(download.path.lastPathComponent)] \(download.status) - \(String(format: "%.0f", download.progress))% (\(download.receivedBytes)/\(download.totalBytes.map { String($0) } ?? "unknown") bytes)")
                downloads = await manager.list()
             }
          }
@@ -130,13 +130,26 @@ struct DownloadRowView: View {
    let item: DownloadItem
    let manager: DownloadManager
    
+   /// A server that omits the content length leaves `totalBytes` nil, so the
+   /// total is not always known even while bytes are arriving.
+   private var byteCount: String {
+      let formatter = ByteCountFormatter()
+      let received = formatter.string(fromByteCount: Int64(item.receivedBytes))
+      let total = item.totalBytes.map { formatter.string(fromByteCount: Int64($0)) } ?? "unknown"
+
+      return "\(received) / \(total)"
+   }
+
    var body: some View {
       VStack(alignment: .leading) {
          Text(item.path.lastPathComponent)
             .font(.headline)
          ProgressView(value: item.progress / 100)
             .progressViewStyle(LinearProgressViewStyle())
-         Text("Status: \(item.status.rawValue)")
+         Text("Status: \(item.status.rawValue) — \(String(format: "%.0f", item.progress))%")
+            .font(.caption)
+            .foregroundColor(.secondary)
+         Text(byteCount)
             .font(.caption)
             .foregroundColor(.secondary)
          

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadActionResponse.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadActionResponse.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// Response from a download action containing the download item and status information.
-public struct DownloadActionResponse: Codable {
+public struct DownloadActionResponse: Encodable {
    public let download: DownloadItem
    public let expectedStatus: DownloadStatus
    public let isExpectedStatus: Bool

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadItem.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadItem.swift
@@ -5,34 +5,58 @@
 
 import Foundation
 
-/// A value type that represents an item to be downloaded.
-/// Used to track the status and progress of a download operation.
-public struct DownloadItem: Identifiable, Codable, Sendable {
+/// Emit-only payload sent to the frontend. Built from a [`DownloadRecord`] with
+/// `progress` derived from `receivedBytes` / `totalBytes`; never persisted and
+/// never decoded, so internal state such as the resume-data path stays out of
+/// the frontend contract. `totalBytes` is nil when the server supplied no
+/// content length, and encodes as an explicit JSON `null`.
+public struct DownloadItem: Identifiable, Encodable, Sendable {
    public var id: URL { path }
    
    public let url: URL
    public let path: URL
-   public private(set) var progress: Double
-   public private(set) var status: DownloadStatus
-   public var resumeDataPath: URL?
-   
-   init(url: URL, path: URL, progress: Double = 0.0, status: DownloadStatus = .idle, resumeDataPath: URL? = nil) {
+   public let receivedBytes: UInt64
+   public let totalBytes: UInt64?
+   public let progress: Double
+   public let status: DownloadStatus
+
+   init(
+      url: URL,
+      path: URL,
+      receivedBytes: UInt64,
+      totalBytes: UInt64?,
+      progress: Double,
+      status: DownloadStatus
+   ) {
       self.url = url
       self.path = path
+      self.receivedBytes = receivedBytes
+      self.totalBytes = totalBytes
       self.progress = progress
       self.status = status
-      self.resumeDataPath = resumeDataPath
    }
    
-   public mutating func setProgress(_ progress: Double) {
-      self.progress = progress
+   enum CodingKeys: String, CodingKey {
+      case url, path, receivedBytes, totalBytes, progress, status
    }
    
-   public mutating func setResumeDataPath(_ resumeDataPath: URL?) {
-      self.resumeDataPath = resumeDataPath
-   }
-   
-   public mutating func setStatus(_ status: DownloadStatus) {
-      self.status = status
+   public func encode(to encoder: Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+
+      try container.encode(url, forKey: .url)
+      try container.encode(path, forKey: .path)
+      try container.encode(receivedBytes, forKey: .receivedBytes)
+      try container.encode(progress, forKey: .progress)
+      try container.encode(status, forKey: .status)
+
+      // The synthesized encoding would use encodeIfPresent and omit the key. The
+      // TypeScript layer coalesces a missing key to null anyway (attachDownload in
+      // guest-js/actions.ts), so this is not load-bearing for the plugin — it keeps
+      // the payload self-describing for anything reading DownloadManagerKit directly.
+      if let totalBytes = totalBytes {
+         try container.encode(totalBytes, forKey: .totalBytes)
+      } else {
+         try container.encodeNil(forKey: .totalBytes)
+      }
    }
 }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os.log
 
 /// A manager class responsible for handling download operations.
 /// Used to provide functionality for downloading files, tracking download progress and handling completion events.
@@ -30,6 +31,15 @@ public final class DownloadManager: NSObject {
    private let store = DownloadStore()
    private let backgroundSessionHandler = BackgroundSessionHandler()
 
+   /// Reconciliation runs once, at init. Assigned before any caller can reach the
+   /// instance and never written again; every public entry point awaits it so a
+   /// caller cannot observe or mutate a record it is about to rewrite.
+   ///
+   /// `var` and optional rather than `let`: as an NSObject subclass every stored
+   /// property must be initialized before `super.init()`, but the task needs the
+   /// `self` that only exists after it.
+   private var reconcileTask: Task<Void, Never>?
+
    override init() {
       super.init()
       sessionDelegate = DownloadSessionDelegate()
@@ -38,6 +48,10 @@ public final class DownloadManager: NSObject {
       // delegateQueue: nil creates a serial operation queue for delegate callbacks by default
       let config = URLSessionConfiguration.background(withIdentifier: Bundle.main.bundleIdentifier!)
       session = URLSession(configuration: config, delegate: sessionDelegate, delegateQueue: nil)
+
+      reconcileTask = Task { [weak self] in
+         await self?.reconcileStore()
+      }
    }
    
    deinit {
@@ -58,7 +72,9 @@ public final class DownloadManager: NSObject {
     - Returns: The list of download operations.
     */
    public func list() async -> [DownloadItem] {
-      return await store.list()
+      await ensureReconciled()
+
+      return await store.list().map { $0.toItem() }
    }
     
    /**
@@ -72,11 +88,13 @@ public final class DownloadManager: NSObject {
     - Returns: The download operation.
     */
    public func get(path: URL) async -> DownloadItem {
-      if let item = await store.findByPath(path) {
-         return item
+      await ensureReconciled()
+
+      if let record = await store.findByPath(path) {
+         return record.toItem()
       }
 
-      return DownloadItem(url: URL(fileURLWithPath: ""), path: path, status: .pending)
+      return DownloadRecord(url: URL(fileURLWithPath: ""), path: path, status: .pending).toItem()
    }
    
    /**
@@ -88,13 +106,15 @@ public final class DownloadManager: NSObject {
     - Returns: The download operation.
     */
    public func create(path: URL, url: URL) async -> DownloadActionResponse {
+      await ensureReconciled()
+
       if let existing = await store.findByPath(path) {
-         return DownloadActionResponse(download: existing, expectedStatus: .idle)
+         return DownloadActionResponse(download: existing.toItem(), expectedStatus: .idle)
       }
 
-      let item = DownloadItem(url: url, path: path)
-      await store.append(item)
-      await emitChanged(item)
+      let record = DownloadRecord(url: url, path: path)
+      await store.append(record)
+      let item = await emitChanged(record)
       
       return DownloadActionResponse(download: item)
    }
@@ -106,21 +126,27 @@ public final class DownloadManager: NSObject {
     - Returns: The download operation.
     */
    public func start(path: URL) async throws -> DownloadActionResponse {
-      guard var item = await store.findByPath(path) else {
+      await ensureReconciled()
+
+      guard var record = await store.findByPath(path) else {
          throw DownloadError.notFound(path.path)
       }
 
-      guard item.status == .idle else {
-         return DownloadActionResponse(download: item, expectedStatus: .inProgress)
+      guard record.status == .idle else {
+         return DownloadActionResponse(download: record.toItem(), expectedStatus: .inProgress)
       }
       
-      let task = session.downloadTask(with: item.url)
+      // Commit InProgress before the task can call back: handleProgress ignores
+      // records that are not InProgress, so a fast first callback would otherwise
+      // be dropped. Rust persists the status before spawning too.
+      record.setStatus(.inProgress)
+      await store.update(record)
+
+      let task = session.downloadTask(with: record.url)
       task.taskDescription = path.path
       task.resume()
       
-      item.setStatus(.inProgress)
-      await store.update(item)
-      await emitChanged(item)
+      let item = await emitChanged(record)
       
       return DownloadActionResponse(download: item)
    }
@@ -132,24 +158,57 @@ public final class DownloadManager: NSObject {
     - Returns: The download operation.
     */
    public func resume(path: URL) async throws -> DownloadActionResponse {
-      guard var item = await store.findByPath(path) else {
+      await ensureReconciled()
+
+      guard var record = await store.findByPath(path) else {
          throw DownloadError.notFound(path.path)
       }
       
-      guard item.status == .paused,
-            let data = loadResumeData(for: item) else {
-         return DownloadActionResponse(download: item, expectedStatus: .inProgress)
+      guard record.status == .paused else {
+         return DownloadActionResponse(download: record.toItem(), expectedStatus: .inProgress)
       }
+
+      // Commit InProgress before starting the task, as in start().
+      record.setStatus(.inProgress)
+      await store.update(record)
       
-      let task = session.downloadTask(withResumeData: data)
+      // Absence is not a refusal. pause() sets .paused whether or not URLSession
+      // produced resume data, so a server without byte-range support leaves a paused
+      // record with none — and requiring it here left that record stuck for good.
+      // Rust and Android also restart from zero when their partial file is missing.
+      let resumeData = loadResumeData(for: record)
+      let task: URLSessionDownloadTask
+
+      if let resumeData, !resumeData.isEmpty {
+         task = session.downloadTask(withResumeData: resumeData)
+      } else {
+         os_log(.info, log: Log.downloadManager,
+                "No usable resume data for %{public}@, restarting from zero",
+                record.path.lastPathComponent)
+
+         // Reset before the task starts, so the first callback is not overwritten.
+         deleteResumeData(for: record)
+         record.setResumeDataPath(nil)
+         record.setBytes(received: 0, total: record.totalBytes)
+         await store.update(record)
+
+         task = session.downloadTask(with: record.url)
+      }
+
       task.taskDescription = path.path
       task.resume()
-      deleteResumeData(for: item)
 
-      item.setResumeDataPath(nil)
-      item.setStatus(.inProgress)
-      await store.update(item)
-      await emitChanged(item)
+      // Only now that the task owns the data can its file go. Deleting it any
+      // earlier means a process death in this window loses the partial download
+      // outright, rather than leaving it resumable. A no-op on the restart path,
+      // which cleared its own file already.
+      deleteResumeData(for: record)
+
+      // In the actor: the task is already running, so a progress callback landing
+      // between a read and a write here would lose its byte count.
+      let updated = await mutateRecord(path: path) { $0.setResumeDataPath(nil) }
+
+      let item = await emitChanged(updated ?? record)
       
       return DownloadActionResponse(download: item)
    }
@@ -161,23 +220,25 @@ public final class DownloadManager: NSObject {
     - Returns: The download operation.
     */
    public func pause(path: URL) async throws -> DownloadActionResponse {
-      guard let item = await store.findByPath(path) else {
+      await ensureReconciled()
+
+      guard let record = await store.findByPath(path) else {
          throw DownloadError.notFound(path.path)
       }
 
-      guard item.status == .inProgress,
+      guard record.status == .inProgress,
             let task = await getDownloadTask(path.path) else {
-         return DownloadActionResponse(download: item, expectedStatus: .paused)
+         return DownloadActionResponse(download: record.toItem(), expectedStatus: .paused)
       }
       
-      // Cancel task and collect resume data via callback. The callback and
-      // handleError may both try to persist resume data; mutateItem serializes
-      // access through the actor so only one wins, and the duplicate is cleaned up.
+      // Three writers can be in flight at once — this callback, the status mutation
+      // below, and handleError. mutateRecord applies each inside the actor, so the
+      // first to persist a path wins and the duplicate file is cleaned up.
       task.cancel(byProducingResumeData: { [weak self] data in
          guard let self, let data else { return }
          let savedURL = self.saveResumeData(data)
          Task {
-            let updated = await self.mutateItem(path: path) { current in
+            let updated = await self.mutateRecord(path: path) { current in
                if current.resumeDataPath == nil {
                   current.setResumeDataPath(savedURL)
                }
@@ -188,11 +249,13 @@ public final class DownloadManager: NSObject {
          }
       })
 
-      let updated = await mutateItem(path: path) { $0.setStatus(.paused) }
-      let result = updated ?? item
-      await emitChanged(result)
-      
-      return DownloadActionResponse(download: result)
+      // Persisting here is what carries the last progress tick's byte count
+      // across the pause.
+      let updated = await mutateRecord(path: path) { $0.setStatus(.paused) }
+      let result = updated ?? record
+      let item = await emitChanged(result)
+
+      return DownloadActionResponse(download: item)
    }
    
    /**
@@ -202,26 +265,28 @@ public final class DownloadManager: NSObject {
     - Returns: The download operation.
     */
    public func cancel(path: URL) async throws -> DownloadActionResponse {
-      guard var item = await store.findByPath(path) else {
+      await ensureReconciled()
+
+      guard var record = await store.findByPath(path) else {
          throw DownloadError.notFound(path.path)
       }
 
-      guard item.status == .idle || item.status == .inProgress || item.status == .paused else {
-         return DownloadActionResponse(download: item, expectedStatus: .canceled)
+      guard record.status == .idle || record.status == .inProgress || record.status == .paused else {
+         return DownloadActionResponse(download: record.toItem(), expectedStatus: .canceled)
       }
       
       if let task = await getDownloadTask(path.path) {
          task.cancel()
       }
       
-      if let _ = loadResumeData(for: item) {
-         deleteResumeData(for: item)
-         item.setResumeDataPath(nil)
+      if let _ = loadResumeData(for: record) {
+         deleteResumeData(for: record)
+         record.setResumeDataPath(nil)
       }
       
-      item.setStatus(.canceled)
-      await store.remove(item)
-      await emitChanged(item)
+      record.setStatus(.canceled)
+      await store.remove(record)
+      let item = await emitChanged(record)
       
       return DownloadActionResponse(download: item)
    }
@@ -232,23 +297,52 @@ public final class DownloadManager: NSObject {
     - Parameters:
       - url: The URL of the download.
       - totalBytesWritten: The total number of bytes transferred so far.
-      - totalBytesExpectedToWrite: The expected length of the file.
+      - totalBytesExpectedToWrite: The expected length of the file, or a negative
+        value when the server did not supply a content length.
     */
    func handleProgress(url: URL, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) async {
-      guard var item = await store.findByUrl(url),
-            totalBytesExpectedToWrite > 0 else { return }
-      
-      let progress = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite) * 100
-      
-      // Throttle progress updates - only emit if progress increases by at least 1%
-      let progressThreshold = 1.0
-      if progress < 100.0 && progress - item.progress < progressThreshold {
-         return
+      guard var record = await store.findByUrl(url),
+            record.status == .inProgress else { return }
+
+      let receivedBytes = UInt64(max(totalBytesWritten, 0))
+      let totalBytes: UInt64? = totalBytesExpectedToWrite > 0 ? UInt64(totalBytesExpectedToWrite) : nil
+
+      // Record a known total independently of the throttle below. handleFinished
+      // reads the total back off the record, so a download that completes without
+      // ever passing the throttle — a small file whose first callback is already
+      // at 100% — would otherwise report no total.
+      if let totalBytes, let updated = await store.setTotalIfChanged(path: record.path, total: totalBytes) {
+         record = updated
       }
       
-      item.setProgress(progress)
-      await store.update(item, persist: false)
-      await emitChanged(item)
+      // This callback may report no total (a resume the server answers without a
+      // content length) for a record that already knows one. setBytes() coalesces
+      // on its own, but the tracker takes the total directly, and without it the
+      // cadence would silently fall back to the byte threshold.
+      let effectiveTotal = totalBytes ?? record.totalBytes
+
+      // Every emission writes the byte count back to the store, so the stored
+      // record is itself the last-emitted baseline. That keeps throttle state off
+      // this class, which would otherwise need synchronizing across callbacks.
+      let tracker = ProgressTracker(
+         lastEmittedBytes: record.receivedBytes,
+         receivedBytes: receivedBytes,
+         totalBytes: effectiveTotal
+      )
+
+      // Completion is reported by handleFinished, which sizes the landed file.
+      guard tracker.shouldEmit, !tracker.isComplete else { return }
+
+      // Bytes only, in the actor: a pause landing between this callback's read and
+      // its write would otherwise be overwritten by this stale InProgress. Emit what
+      // the store returned, for the same reason.
+      guard let updated = await mutateRecord(path: record.path, persist: false, {
+         $0.setBytes(received: receivedBytes, total: effectiveTotal)
+      }) else {
+         return
+      }
+
+      await emitChanged(updated)
    }
 
    /**
@@ -260,26 +354,55 @@ public final class DownloadManager: NSObject {
       - location: The temporary location of the downloaded file.
     */
    func handleFinished(url: URL, location: URL) async {
-      guard var item = await store.findByUrl(url) else {
+      guard var record = await store.findByUrl(url) else {
          try? FileManager.default.removeItem(at: location)
          return
       }
 
-      // Ensure parent directory exists.
-      let parentDirectory = item.path.deletingLastPathComponent()
-      if !FileManager.default.fileExists(atPath: parentDirectory.path) {
-         try? FileManager.default.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+      do {
+         try DownloadManager.placeDownloadedFile(from: location, to: record.path)
+      } catch {
+         os_log(.error, log: Log.downloadManager, "Failed to place %{public}@: %{public}@",
+                record.path.lastPathComponent, error.localizedDescription)
+
+         // No record names this temp file, so it is removed here or never — and a
+         // record left InProgress with no task behind it would never emit again.
+         try? FileManager.default.removeItem(at: location)
+
+         record.setStatus(.canceled)
+         await store.remove(record)
+         await emitChanged(record)
+
+         return
       }
 
-      // Remove existing item (if found) and move downloaded item to destination path.
-      try? FileManager.default.removeItem(at: item.path)
-      try? FileManager.default.moveItem(at: location, to: item.path)
+      // Size the file that landed. URLSession's counters already include the
+      // resume offset, so this agrees with them; it is here because the file on
+      // disk is the authority on what was actually written, and the last progress
+      // callback may have been throttled away before completion.
+      let receivedBytes = DownloadManager.fileSize(at: record.path) ?? record.receivedBytes
 
-      item.setStatus(.completed)
-      await store.remove(item)
-      await emitChanged(item)
+      record.setBytes(received: receivedBytes, total: record.totalBytes)
+      record.setStatus(.completed)
+      await store.remove(record)
+      await emitChanged(record)
    }
    
+   /// Places a finished download's temporary file at its destination, creating the
+   /// parent directory and replacing whatever is already there. Static and throwing
+   /// so the failure path can be tested; moveItem() fails rather than replacing, so
+   /// the destination is removed first.
+   static func placeDownloadedFile(from location: URL, to destination: URL) throws {
+      let parentDirectory = destination.deletingLastPathComponent()
+
+      if !FileManager.default.fileExists(atPath: parentDirectory.path) {
+         try FileManager.default.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+      }
+
+      try? FileManager.default.removeItem(at: destination)
+      try FileManager.default.moveItem(at: location, to: destination)
+   }
+
    /**
     Handler for download errors. Called by DownloadSessionDelegate.
 
@@ -289,14 +412,14 @@ public final class DownloadManager: NSObject {
     */
    func handleError(url: URL, error: Error?) async {
       guard let error = error,
-            let item = await store.findByUrl(url) else { return }
+            let record = await store.findByUrl(url) else { return }
       
       // Cancellation with resume data. For user-invoked pauses, pause() may have
       // already persisted resume data. The atomic mutate ensures only one path wins.
       if let data = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data {
          let savedURL = saveResumeData(data)
          
-         let updated = await mutateItem(path: item.path) { current in
+         let updated = await mutateRecord(path: record.path) { current in
             current.setStatus(.paused)
             if current.resumeDataPath == nil {
                current.setResumeDataPath(savedURL)
@@ -315,8 +438,8 @@ public final class DownloadManager: NSObject {
       }
       
       // Download failed - update status and clean up
-      deleteResumeData(for: item)
-      if let updated = await mutateItem(path: item.path, { $0.setStatus(.canceled) }) {
+      deleteResumeData(for: record)
+      if let updated = await mutateRecord(path: record.path, { $0.setStatus(.canceled) }) {
          await store.remove(updated)
          await emitChanged(updated)
       }
@@ -333,8 +456,77 @@ public final class DownloadManager: NSObject {
       }
    }
 
-   func loadResumeData(for item: DownloadItem) -> Data? {
-      guard let url = item.resumeDataPath else { return nil }
+   private func ensureReconciled() async {
+      await reconcileTask?.value
+   }
+
+   /// Decides what a record left `inProgress` with no task behind it should become.
+   /// Returns nil when the record needs no change.
+   ///
+   /// `start()` and `resume()` both commit `inProgress` to the store before calling
+   /// `task.resume()`. A process death in that window strands the record: `start()`
+   /// requires `idle` and `resume()` requires `paused`, so nothing but `cancel()`
+   /// would clear it. A record with resume data can still be resumed, so it becomes
+   /// `paused` and keeps its byte count; one without restarts from scratch, so it
+   /// becomes `idle` at zero. The total is kept either way — headers established it.
+   static func reconciledRecord(_ record: DownloadRecord, hasLiveTask: Bool) -> DownloadRecord? {
+      guard record.status == .inProgress, !hasLiveTask else { return nil }
+
+      var updated = record
+
+      if record.resumeDataPath == nil {
+         updated.setBytes(received: 0, total: record.totalBytes)
+         updated.setStatus(.idle)
+      } else {
+         updated.setStatus(.paused)
+      }
+
+      return updated
+   }
+
+   /// Reconciles the store against the session's live tasks.
+   ///
+   /// Background-session tasks outlive the process and are restored alongside the
+   /// session, so a record is reverted only when the session reports no task for
+   /// its path — otherwise a download that is genuinely still running would be
+   /// clobbered. Android's reconcileStoreOnInit() needs no such check, because
+   /// WorkManager reruns the worker and it rewrites the status itself.
+   ///
+   /// That live-task check is also why the delegate handlers — handleProgress,
+   /// handleFinished, handleError — do not await ensureReconciled(), and must not
+   /// start doing so: gating them would serialize every progress callback behind
+   /// reconciliation for no benefit. They are already safe against it because
+   ///
+   /// - this reverts only records with no live task, while a callback fires only
+   ///   for a task that exists, so the two act on disjoint records;
+   /// - a new task can only appear via start()/resume(), which do await the gate,
+   ///   so none can be created while this is running; and
+   /// - if a restored task finishes mid-reconcile and handleFinished removes its
+   ///   record, the batched update below cannot resurrect it — DownloadStore's
+   ///   update(_ records:) writes only paths that still exist.
+   private func reconcileStore() async {
+      let livePaths = Set(await session.allTasks.compactMap { $0.taskDescription })
+
+      var reconciled: [DownloadRecord] = []
+
+      for record in await store.list() {
+         guard let updated = DownloadManager.reconciledRecord(
+            record,
+            hasLiveTask: livePaths.contains(record.path.path)
+         ) else {
+            continue
+         }
+
+         reconciled.append(updated)
+         os_log(.info, log: Log.downloadManager, "Reconciled %{public}@ to %{public}@",
+                record.path.lastPathComponent, String(describing: updated.status))
+      }
+
+      await store.update(reconciled)
+   }
+
+   func loadResumeData(for record: DownloadRecord) -> Data? {
+      guard let url = record.resumeDataPath else { return nil }
       return try? Data(contentsOf: url)
    }
    
@@ -345,16 +537,20 @@ public final class DownloadManager: NSObject {
       return url
    }
    
-   func deleteResumeData(for item: DownloadItem) {
-      guard let url = item.resumeDataPath else { return }
+   func deleteResumeData(for record: DownloadRecord) {
+      guard let url = record.resumeDataPath else { return }
       try? FileManager.default.removeItem(at: url)
    }
    
-   private func mutateItem(path: URL, _ body: (inout DownloadItem) -> Void) async -> DownloadItem? {
-      guard var item = await store.findByPath(path) else { return nil }
-      body(&item)
-      await store.update(item, persist: true)
-      return item
+   /// Applies `body` to the stored record at `path` and returns what actually landed,
+   /// or nil when no record has that path. One await, so the read and the write cannot
+   /// be interleaved; see DownloadStore.mutate().
+   private func mutateRecord(
+      path: URL,
+      persist: Bool = true,
+      _ body: @Sendable (inout DownloadRecord) -> Void
+   ) async -> DownloadRecord? {
+      return await store.mutate(path: path, persist: persist, body)
    }
    
    func getDownloadTask(_ path: String) async -> URLSessionDownloadTask? {
@@ -363,7 +559,20 @@ public final class DownloadManager: NSObject {
          .first { $0.taskDescription == path }
    }
 
-   func emitChanged(_ item: DownloadItem) async {
+   /// Emits the public payload derived from `record` and returns it for reuse in
+   /// a `DownloadActionResponse`.
+   @discardableResult
+   func emitChanged(_ record: DownloadRecord) async -> DownloadItem {
+      let item = record.toItem()
       await downloadContinuation.yield(item)
+      return item
+   }
+
+   static func fileSize(at url: URL) -> UInt64? {
+      guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let size = attributes[.size] as? NSNumber else {
+         return nil
+      }
+      return size.uint64Value
    }
 }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadRecord.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadRecord.swift
@@ -1,0 +1,82 @@
+//
+//  DownloadRecord.swift
+//  DownloadManagerKit
+//
+
+import Foundation
+
+/// Persisted download record, stored in `downloads.json`. Mirrors the Rust
+/// `DownloadRecord` in `crates/download-manager/src/models.rs`.
+///
+/// Carries no `progress` — that is derived, and lives only on [`DownloadItem`],
+/// the type sent to the frontend. `resumeDataPath` is an internal URLSession
+/// concern that deliberately never leaves this type.
+struct DownloadRecord: Identifiable, Codable, Sendable {
+   var id: URL { path }
+
+   let url: URL
+   let path: URL
+   private(set) var receivedBytes: UInt64
+   private(set) var totalBytes: UInt64?
+   private(set) var status: DownloadStatus
+   var resumeDataPath: URL?
+
+   init(
+      url: URL,
+      path: URL,
+      receivedBytes: UInt64 = 0,
+      totalBytes: UInt64? = nil,
+      status: DownloadStatus = .idle,
+      resumeDataPath: URL? = nil
+   ) {
+      self.url = url
+      self.path = path
+      self.receivedBytes = receivedBytes
+      self.totalBytes = totalBytes
+      self.status = status
+      self.resumeDataPath = resumeDataPath
+   }
+
+   /// Sets the byte counts. A nil total means "this callback did not report one",
+   /// not "there is none": a resume the server answers without a content length
+   /// cannot know a total an earlier response already established, so nil never
+   /// erases a total the record holds. Pass a value to widen or correct it.
+   mutating func setBytes(received: UInt64, total: UInt64? = nil) {
+      self.receivedBytes = received
+      self.totalBytes = total ?? self.totalBytes
+   }
+
+   mutating func setResumeDataPath(_ resumeDataPath: URL?) {
+      self.resumeDataPath = resumeDataPath
+   }
+
+   mutating func setStatus(_ status: DownloadStatus) {
+      self.status = status
+   }
+
+   /// Builds the public payload, computing `progress` from the byte counts.
+   ///
+   /// A completed download always reports 100%, even without a content length.
+   /// In flight without one it reports 0%, since `receivedBytes` is then the
+   /// only meaningful signal.
+   func toItem() -> DownloadItem {
+      let progress: Double
+
+      if status == .completed {
+         progress = 100.0
+      } else if let total = totalBytes, total > 0 {
+         progress = min(max((Double(receivedBytes) / Double(total)) * 100.0, 0.0), 100.0)
+      } else {
+         progress = 0.0
+      }
+
+      return DownloadItem(
+         url: url,
+         path: path,
+         receivedBytes: receivedBytes,
+         totalBytes: totalBytes,
+         progress: progress,
+         status: status
+      )
+   }
+}

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStatus.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStatus.swift
@@ -4,7 +4,7 @@
 //
 
 /// Represents the various states of a download item.
-public enum DownloadStatus: String, Codable, Sendable {
+public enum DownloadStatus: String, Codable, CaseIterable, Sendable {
    /// Status could not be determined.
    case unknown
    /// Download has not yet been created/persisted.

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStore.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStore.swift
@@ -6,31 +6,39 @@
 import Foundation
 import os.log
 
-/// Thread-safe store for the downloads array.
+/// Thread-safe store for the download records array, persisted to an atomically
+/// written JSON file.
 actor DownloadStore {
-   private var downloads: [DownloadItem]
-   private static let savePath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("downloads.json")
+   private var downloads: [DownloadRecord]
+   private let savePath: URL
 
-   init() {
-      downloads = DownloadStore.load()
+   private static var defaultSavePath: URL {
+      FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("downloads.json")
    }
 
-   func list() -> [DownloadItem] { downloads }
+   /// - Parameter savePath: Where the store is persisted. Injectable so tests can
+   ///   work against a temporary file rather than the app's Documents directory.
+   init(savePath: URL = DownloadStore.defaultSavePath) {
+      self.savePath = savePath
+      self.downloads = DownloadStore.load(from: savePath)
+   }
+
+   func list() -> [DownloadRecord] { downloads }
    
-   func findByPath(_ path: URL) -> DownloadItem? {
+   func findByPath(_ path: URL) -> DownloadRecord? {
       downloads.first(where: { $0.path == path })
    }
    
-   func findByUrl(_ url: URL) -> DownloadItem? {
+   func findByUrl(_ url: URL) -> DownloadRecord? {
       downloads.first(where: { $0.url == url })
    }
    
-   func append(_ item: DownloadItem) {
+   func append(_ item: DownloadRecord) {
       downloads.append(item)
       save()
    }
    
-   func update(_ item: DownloadItem, persist: Bool = true) {
+   func update(_ item: DownloadRecord, persist: Bool = true) {
       if let index = downloads.firstIndex(where: { $0.path == item.path }) {
          downloads[index] = item
       }
@@ -39,28 +47,86 @@ actor DownloadStore {
       }
    }
    
-   func remove(_ item: DownloadItem) {
+   /// Records a newly-learned total in a single actor hop, returning the updated
+   /// record, or nil when the total was already known.
+   ///
+   /// Progress callbacks arrive as unordered tasks, so a compare-and-set composed
+   /// from a separate `findByUrl` and `update` lets several callbacks each read an
+   /// unknown total and each act on it. Deliberately does not persist: pause,
+   /// cancel and completion all write the record, and this runs on the hottest
+   /// callback in the system.
+   func setTotalIfChanged(path: URL, total: UInt64) -> DownloadRecord? {
+      guard let index = downloads.firstIndex(where: { $0.path == path }),
+            downloads[index].totalBytes != total else {
+         return nil
+      }
+
+      downloads[index].setBytes(received: downloads[index].receivedBytes, total: total)
+
+      return downloads[index]
+   }
+
+   /// Applies `body` in one actor hop and returns the stored record, or nil when no
+   /// record has that path. Composed from `findByPath` and `update` it would suspend
+   /// between read and write and lose concurrent changes; `body` is synchronous for
+   /// the same reason.
+   func mutate(path: URL, persist: Bool, _ body: @Sendable (inout DownloadRecord) -> Void) -> DownloadRecord? {
+      guard let index = downloads.firstIndex(where: { $0.path == path }) else {
+         return nil
+      }
+
+      body(&downloads[index])
+
+      if persist {
+         save()
+      }
+
+      return downloads[index]
+   }
+
+   /// Applies several record updates with a single write.
+   ///
+   /// Reconciliation can revert many records at once; one write per record would
+   /// re-encode and rewrite the whole file that many times. Unknown paths are
+   /// ignored.
+   func update(_ records: [DownloadRecord]) {
+      guard !records.isEmpty else { return }
+
+      for record in records {
+         if let index = downloads.firstIndex(where: { $0.path == record.path }) {
+            downloads[index] = record
+         }
+      }
+
+      save()
+   }
+
+   func remove(_ item: DownloadRecord) {
       if let index = downloads.firstIndex(where: { $0.path == item.path }) {
          downloads.remove(at: index)
       }
       save()
    }
    
-   private static func load() -> [DownloadItem] {
+   /// Decodes the persisted store.
+   ///
+   /// Note that one malformed element fails the whole array, discarding every other
+   /// download in the file. Making that per-record is tracked in #64.
+   static func load(from savePath: URL) -> [DownloadRecord] {
       do {
          let data = try Data(contentsOf: savePath)
-         return try JSONDecoder().decode([DownloadItem].self, from: data)
+         return try JSONDecoder().decode([DownloadRecord].self, from: data)
       } catch {
          os_log(.error, log: Log.downloadStore, "Failed to load download store: %{public}@", error.localizedDescription)
          return []
       }
    }
-   
+
    private func save() {
       let encoder = JSONEncoder()
       do {
          let data = try encoder.encode(downloads)
-         try data.write(to: DownloadStore.savePath, options: .atomic)
+         try data.write(to: savePath, options: .atomic)
       } catch {
          os_log(.error, log: Log.downloadStore, "Failed to save download store: %{public}@", error.localizedDescription)
       }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/Logger.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/Logger.swift
@@ -8,4 +8,5 @@ import os.log
 
 enum Log {
    static let downloadStore = OSLog(subsystem: "DownloadManagerKit", category: "DownloadStore")
+   static let downloadManager = OSLog(subsystem: "DownloadManagerKit", category: "DownloadManager")
 }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/ProgressTracker.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/ProgressTracker.swift
@@ -1,0 +1,59 @@
+//
+//  ProgressTracker.swift
+//  DownloadManagerKit
+//
+
+import Foundation
+
+/// Decides when a progress update should be emitted: on every change of integer
+/// percent when `totalBytes` is known and positive, otherwise every
+/// `bytesThreshold` bytes.
+///
+/// Mirrors the emission rule of the Rust `ProgressTracker` in
+/// `crates/download-manager/src/downloader.rs`. Rust accumulates chunk sizes as
+/// it streams; URLSession reports a cumulative count per callback, so this
+/// compares against the last count emitted instead of holding state.
+struct ProgressTracker {
+   static let bytesThreshold: UInt64 = 1024 * 1024
+
+   private let receivedBytes: UInt64
+   private let totalBytes: UInt64?
+   private let lastEmittedBytes: UInt64
+
+   init(lastEmittedBytes: UInt64, receivedBytes: UInt64, totalBytes: UInt64?) {
+      self.receivedBytes = receivedBytes
+      self.totalBytes = totalBytes
+      self.lastEmittedBytes = lastEmittedBytes
+   }
+
+   var shouldEmit: Bool {
+      // A restarted download (rejected resume data, or a server that stops
+      // honouring Range) reports fewer bytes than the store last saw. Emit so
+      // the baseline resets, rather than going quiet until it climbs back past
+      // the old count. Also guards the unsigned subtraction below. Rust owns its
+      // accumulator, so it never sees this.
+      guard receivedBytes >= lastEmittedBytes else {
+         return true
+      }
+
+      guard let total = totalBytes, total > 0 else {
+         return (receivedBytes - lastEmittedBytes) >= Self.bytesThreshold
+      }
+
+      let percent = ((receivedBytes * 100) / total)
+      let lastEmittedPercent = ((lastEmittedBytes * 100) / total)
+
+      // `percent >= 100` never emits — the call site guards on it. Inert here, where
+      // no store poll follows; kept so the three trackers read alike.
+      return (percent >= 100 || percent > lastEmittedPercent)
+   }
+
+   var isComplete: Bool {
+      // Positive, not merely non-nil — a zero total would otherwise read as
+      // complete from the first byte. Mirrors the Android guard.
+      guard let total = totalBytes, total > 0 else {
+         return false
+      }
+      return receivedBytes >= total
+   }
+}

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadManagerTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadManagerTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import DownloadManagerKit
+
+final class DownloadManagerTests: XCTestCase {
+
+   private func inProgressRecord(resumeDataPath: URL? = nil) -> DownloadRecord {
+      return DownloadRecord(
+         url: URL(string: "http://example.com/file.mp4")!,
+         path: URL(fileURLWithPath: "/tmp/file.mp4"),
+         receivedBytes: 500,
+         totalBytes: 1000,
+         status: .inProgress,
+         resumeDataPath: resumeDataPath
+      )
+   }
+
+   private func resumeDataURL() -> URL {
+      return URL(fileURLWithPath: "/tmp/abc.resumedata")
+   }
+
+   // MARK: - Reconciliation
+
+   func testLiveTaskIsLeftAlone() {
+      // A background-session task outlives the process, so an InProgress record
+      // with a task still behind it is genuinely running.
+      let record = inProgressRecord()
+
+      XCTAssertNil(DownloadManager.reconciledRecord(record, hasLiveTask: true))
+   }
+
+   func testStrandedRecordWithResumeDataBecomesPaused() {
+      let record = inProgressRecord(resumeDataPath: resumeDataURL())
+
+      let reconciled = DownloadManager.reconciledRecord(record, hasLiveTask: false)
+
+      XCTAssertEqual(reconciled?.status, .paused)
+      // The resume data represents these bytes, so the count stands.
+      XCTAssertEqual(reconciled?.receivedBytes, 500)
+      XCTAssertEqual(reconciled?.totalBytes, 1000)
+      XCTAssertEqual(reconciled?.resumeDataPath, resumeDataURL())
+   }
+
+   func testStrandedRecordWithoutResumeDataBecomesIdleAtZero() {
+      let record = inProgressRecord()
+
+      let reconciled = DownloadManager.reconciledRecord(record, hasLiveTask: false)
+
+      XCTAssertEqual(reconciled?.status, .idle)
+      // Nothing to resume from, so the download restarts from scratch.
+      XCTAssertEqual(reconciled?.receivedBytes, 0)
+      // The total came from headers and is still true of the remote file.
+      XCTAssertEqual(reconciled?.totalBytes, 1000)
+   }
+
+   func testNonInProgressRecordsAreLeftAlone() {
+      // Derived from the enum so a status added later is covered automatically.
+      for status in DownloadStatus.allCases where status != .inProgress {
+         var record = inProgressRecord(resumeDataPath: resumeDataURL())
+         record.setStatus(status)
+
+         XCTAssertNil(
+            DownloadManager.reconciledRecord(record, hasLiveTask: false),
+            "\(status) should not be reconciled"
+         )
+      }
+   }
+
+   // MARK: - Placing the downloaded file
+
+   func testPlacingDownloadedFileCreatesMissingParentDirectory() throws {
+      let source = try makeTemporaryFile(contents: "payload")
+      let destination = makeTemporaryDirectoryURL()
+         .appendingPathComponent("nested", isDirectory: true)
+         .appendingPathComponent("file.mp4")
+
+      try DownloadManager.placeDownloadedFile(from: source, to: destination)
+
+      XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "payload")
+      // The move must consume the temporary file, not copy it.
+      XCTAssertFalse(FileManager.default.fileExists(atPath: source.path))
+   }
+
+   func testPlacingDownloadedFileReplacesAnExistingFile() throws {
+      let source = try makeTemporaryFile(contents: "new")
+      let destination = try makeTemporaryFile(contents: "stale")
+
+      try DownloadManager.placeDownloadedFile(from: source, to: destination)
+
+      XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "new")
+   }
+
+   func testPlacingDownloadedFileThrowsWhenTheDestinationIsUnreachable() throws {
+      let source = try makeTemporaryFile(contents: "payload")
+
+      // A regular file occupies the destination's parent, so the move cannot land.
+      // Unthrown, this reports a completed download for a file that is not there.
+      let blockingFile = try makeTemporaryFile(contents: "not a directory")
+      let destination = blockingFile.appendingPathComponent("file.mp4")
+
+      XCTAssertThrowsError(try DownloadManager.placeDownloadedFile(from: source, to: destination))
+   }
+
+   func testPlacingDownloadedFileThrowsWhenTheSourceIsMissing() {
+      let source = makeTemporaryDirectoryURL().appendingPathComponent("gone.tmp")
+      let destination = makeTemporaryDirectoryURL().appendingPathComponent("file.mp4")
+
+      XCTAssertThrowsError(try DownloadManager.placeDownloadedFile(from: source, to: destination))
+   }
+
+   // MARK: - Helpers
+
+   /// A directory unique to the calling test, removed when the test finishes.
+   private func makeTemporaryDirectoryURL() -> URL {
+      let directory = FileManager.default.temporaryDirectory
+         .appendingPathComponent(UUID().uuidString, isDirectory: true)
+
+      try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+      addTeardownBlock {
+         try? FileManager.default.removeItem(at: directory)
+      }
+
+      return directory
+   }
+
+   private func makeTemporaryFile(contents: String) throws -> URL {
+      let url = makeTemporaryDirectoryURL().appendingPathComponent(UUID().uuidString)
+
+      try contents.write(to: url, atomically: true, encoding: .utf8)
+
+      return url
+   }
+}

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadRecordTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadRecordTests.swift
@@ -1,0 +1,225 @@
+import XCTest
+@testable import DownloadManagerKit
+
+final class DownloadRecordTests: XCTestCase {
+
+   private func sampleRecord() -> DownloadRecord {
+      return DownloadRecord(
+         url: URL(string: "http://example.com/file.mp4")!,
+         path: URL(fileURLWithPath: "/tmp/file.mp4"),
+         receivedBytes: 0,
+         totalBytes: nil,
+         status: .idle
+      )
+   }
+
+   // MARK: - Mutation
+
+   func testSetBytes() {
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+
+      XCTAssertEqual(record.receivedBytes, 500)
+      XCTAssertEqual(record.totalBytes, 1000)
+      XCTAssertEqual(record.status, .idle)
+      XCTAssertEqual(record.url, sampleRecord().url)
+      XCTAssertEqual(record.path, sampleRecord().path)
+   }
+
+   func testSetBytesWithNilTotalPreservesAKnownTotal() {
+      // A resume answered without a content length reports no total — "none given",
+      // not "there is none" — so it must not erase an established one.
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+      record.setBytes(received: 600)
+
+      XCTAssertEqual(record.receivedBytes, 600)
+      XCTAssertEqual(record.totalBytes, 1000)
+   }
+
+   func testSetStatusPreservesBytes() {
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+
+      var paused = record
+      paused.setStatus(.paused)
+      XCTAssertEqual(paused.receivedBytes, 500)
+      XCTAssertEqual(paused.totalBytes, 1000)
+      XCTAssertEqual(paused.status, .paused)
+
+      // Status transitions preserve the factual byte counts, including completion.
+      var completed = record
+      completed.setStatus(.completed)
+      XCTAssertEqual(completed.receivedBytes, 500)
+      XCTAssertEqual(completed.totalBytes, 1000)
+      XCTAssertEqual(completed.status, .completed)
+      XCTAssertEqual(completed.toItem().progress, 100.0)
+   }
+
+   func testSetStatusCompletedWithUnknownSize() {
+      // Completed with unknown size preserves receivedBytes.
+      var record = sampleRecord()
+      record.setBytes(received: 5000, total: nil)
+      record.setStatus(.completed)
+
+      XCTAssertEqual(record.receivedBytes, 5000)
+      XCTAssertNil(record.totalBytes)
+   }
+
+   // MARK: - Progress derivation
+
+   func testToItemWithKnownSize() {
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+
+      let item = record.toItem()
+      XCTAssertEqual(item.progress, 50.0)
+      XCTAssertEqual(item.receivedBytes, 500)
+      XCTAssertEqual(item.totalBytes, 1000)
+   }
+
+   func testToItemClampsProgressTo100Percent() {
+      var record = sampleRecord()
+      record.setBytes(received: 1500, total: 1000)
+
+      XCTAssertEqual(record.toItem().progress, 100.0)
+   }
+
+   func testToItemWithUnknownSize() {
+      let record = sampleRecord()
+      XCTAssertEqual(record.toItem().progress, 0.0)
+
+      // Completed with unknown size still reports 100%.
+      var completed = record
+      completed.setStatus(.completed)
+      XCTAssertEqual(completed.toItem().progress, 100.0)
+   }
+
+   func testToItemWithZeroTotal() {
+      // A zero content length must not divide by zero.
+      var record = sampleRecord()
+      record.setBytes(received: 0, total: 0)
+
+      XCTAssertEqual(record.toItem().progress, 0.0)
+   }
+
+   // MARK: - Encoding
+
+   func testItemEncodesTotalBytesAsExplicitNull() throws {
+      // The key is always present, so the payload matches the frontend contract
+      // without relying on the TypeScript layer to coalesce a missing key.
+      let record = sampleRecord()
+      let json = try JSONSerialization.jsonObject(
+         with: try JSONEncoder().encode(record.toItem())
+      ) as? [String: Any]
+
+      XCTAssertTrue(try XCTUnwrap(json).keys.contains("totalBytes"))
+      XCTAssertTrue(try XCTUnwrap(json)["totalBytes"] is NSNull)
+   }
+
+   func testItemEncodesByteFields() throws {
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+
+      let json = try XCTUnwrap(
+         try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(record.toItem())
+         ) as? [String: Any]
+      )
+
+      XCTAssertEqual(json["receivedBytes"] as? UInt64, 500)
+      XCTAssertEqual(json["totalBytes"] as? UInt64, 1000)
+      XCTAssertEqual(json["progress"] as? Double, 50.0)
+      XCTAssertEqual(json["status"] as? String, "idle")
+   }
+
+   func testItemEncodesExactlyTheContractKeys() throws {
+      // DownloadItem hand-writes encode(to:) so a nil total becomes an explicit
+      // null. That means a property added without a matching encode line still
+      // compiles and silently vanishes from the payload — on iOS only, since Rust
+      // and Kotlin derive their encoders. Pin the whole key set, not one key.
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+      record.setResumeDataPath(URL(fileURLWithPath: "/tmp/abc.resumedata"))
+
+      let json = try XCTUnwrap(
+         try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(record.toItem())
+         ) as? [String: Any]
+      )
+
+      XCTAssertEqual(
+         Set(json.keys),
+         ["url", "path", "receivedBytes", "totalBytes", "progress", "status"]
+      )
+   }
+
+   func testItemDoesNotEncodeResumeDataPath() throws {
+      // resumeDataPath is internal to URLSession and must not reach the frontend.
+      var record = sampleRecord()
+      record.setResumeDataPath(URL(fileURLWithPath: "/tmp/abc.resumedata"))
+
+      let json = try XCTUnwrap(
+         try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(record.toItem())
+         ) as? [String: Any]
+      )
+
+      XCTAssertFalse(json.keys.contains("resumeDataPath"))
+   }
+
+   func testRecordDecodesPersistedWireFormat() throws {
+      // A literal payload, not a round trip, which would pass even if the
+      // field names drifted on both sides together.
+      let json = """
+      {"url":"http://example.com/f.mp4","path":"file:///tmp/f.mp4",\
+      "receivedBytes":500,"totalBytes":1000,"status":"paused"}
+      """
+
+      let record = try JSONDecoder().decode(DownloadRecord.self, from: Data(json.utf8))
+
+      XCTAssertEqual(record.receivedBytes, 500)
+      XCTAssertEqual(record.totalBytes, 1000)
+      XCTAssertEqual(record.status, .paused)
+      // progress is derived via toItem(), not stored.
+      XCTAssertEqual(record.toItem().progress, 50.0)
+   }
+
+
+   func testRecordRoundTripsThroughJSON() throws {
+      var record = sampleRecord()
+      record.setBytes(received: 500, total: 1000)
+      record.setStatus(.paused)
+
+      let decoded = try JSONDecoder().decode(
+         DownloadRecord.self,
+         from: try JSONEncoder().encode(record)
+      )
+
+      XCTAssertEqual(decoded.receivedBytes, 500)
+      XCTAssertEqual(decoded.totalBytes, 1000)
+      XCTAssertEqual(decoded.status, .paused)
+      // progress is derived via toItem(), not stored.
+      XCTAssertEqual(decoded.toItem().progress, 50.0)
+   }
+
+   // MARK: - Action response
+
+   func testActionResponse() {
+      let item = sampleRecord().toItem()
+
+      // The single-argument initializer reports the status as expected.
+      let response = DownloadActionResponse(download: item)
+      XCTAssertTrue(response.isExpectedStatus)
+      XCTAssertEqual(response.expectedStatus, .idle)
+
+      // A matching expected status is still expected.
+      let matching = DownloadActionResponse(download: item, expectedStatus: .idle)
+      XCTAssertTrue(matching.isExpectedStatus)
+
+      // A mismatched expected status is not.
+      let mismatched = DownloadActionResponse(download: item, expectedStatus: .inProgress)
+      XCTAssertFalse(mismatched.isExpectedStatus)
+      XCTAssertEqual(mismatched.expectedStatus, .inProgress)
+   }
+}

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadStoreTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadStoreTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+@testable import DownloadManagerKit
+
+final class DownloadStoreTests: XCTestCase {
+
+   private var savePath: URL!
+
+   override func setUp() {
+      super.setUp()
+      savePath = FileManager.default.temporaryDirectory
+         .appendingPathComponent(UUID().uuidString)
+         .appendingPathComponent("downloads.json")
+      try? FileManager.default.createDirectory(
+         at: savePath.deletingLastPathComponent(),
+         withIntermediateDirectories: true
+      )
+   }
+
+   override func tearDown() {
+      try? FileManager.default.removeItem(at: savePath.deletingLastPathComponent())
+      savePath = nil
+      super.tearDown()
+   }
+
+   private func write(_ json: String) {
+      try? Data(json.utf8).write(to: savePath)
+   }
+
+   private func record(path: String, received: UInt64 = 0, total: UInt64? = 1000) -> DownloadRecord {
+      return DownloadRecord(
+         url: URL(string: "http://example.com/\(path)")!,
+         path: URL(fileURLWithPath: "/tmp/\(path)"),
+         receivedBytes: received,
+         totalBytes: total,
+         status: .paused
+      )
+   }
+
+   // MARK: - Loading
+
+   func testLoadsPersistedRecords() {
+      write("""
+      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","receivedBytes":500,"totalBytes":1000,"status":"paused"}]
+      """)
+
+      let records = DownloadStore.load(from: savePath)
+
+      XCTAssertEqual(records.count, 1)
+      XCTAssertEqual(records.first?.receivedBytes, 500)
+      XCTAssertEqual(records.first?.totalBytes, 1000)
+      XCTAssertEqual(records.first?.status, .paused)
+   }
+
+
+   func testMissingFileLoadsEmpty() {
+      XCTAssertEqual(DownloadStore.load(from: savePath).count, 0)
+   }
+
+   func testOneUnreadableRecordDiscardsTheWholeStore() {
+      // Pins today's behaviour, which is not the behaviour we want: the array is
+      // decoded in one call, so the middle element takes both good records with it.
+      // Invert this test when per-record decoding lands (#64).
+      write("""
+      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","receivedBytes":1,"status":"paused"},
+       {"url":"http://example.com/b.mp4","status":"paused"},
+       {"url":"http://example.com/c.mp4","path":"file:///tmp/c.mp4","receivedBytes":3,"status":"idle"}]
+      """)
+
+      XCTAssertEqual(DownloadStore.load(from: savePath).count, 0)
+   }
+
+   func testMalformedFileLoadsEmpty() {
+      write("this is not json")
+
+      XCTAssertEqual(DownloadStore.load(from: savePath).count, 0)
+   }
+
+   func testUnknownKeysAreIgnored() {
+      write("""
+      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","receivedBytes":7,"status":"idle","somethingNew":42}]
+      """)
+
+      XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 7)
+   }
+
+   // MARK: - Persistence
+
+   func testAppendPersists() async {
+      let store = DownloadStore(savePath: savePath)
+      await store.append(record(path: "a.mp4", received: 42))
+
+      XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 42)
+   }
+
+   func testUpdateWithoutPersistLeavesTheFileUntouched() async throws {
+      let store = DownloadStore(savePath: savePath)
+      await store.append(record(path: "a.mp4", received: 42))
+      let before = try Data(contentsOf: savePath)
+
+      var updated = record(path: "a.mp4")
+      updated.setBytes(received: 999)
+      await store.update(updated, persist: false)
+
+      // In memory only: this runs on every progress tick.
+      let inMemory = await store.findByPath(updated.path)?.receivedBytes
+      XCTAssertEqual(inMemory, 999)
+      XCTAssertEqual(try Data(contentsOf: savePath), before)
+      XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 42)
+   }
+
+   func testUpdatePersistsWhenAsked() async {
+      let store = DownloadStore(savePath: savePath)
+      await store.append(record(path: "a.mp4", received: 42))
+
+      var updated = record(path: "a.mp4")
+      updated.setBytes(received: 999)
+      await store.update(updated)
+
+      XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 999)
+   }
+
+   func testBatchUpdateAppliesEveryRecord() async {
+      let store = DownloadStore(savePath: savePath)
+      await store.append(record(path: "a.mp4", received: 1))
+      await store.append(record(path: "b.mp4", received: 2))
+
+      var first = record(path: "a.mp4")
+      first.setBytes(received: 10)
+      var second = record(path: "b.mp4")
+      second.setBytes(received: 20)
+      await store.update([first, second])
+
+      let persisted = DownloadStore.load(from: savePath).sorted { $0.receivedBytes < $1.receivedBytes }
+      XCTAssertEqual(persisted.map { $0.receivedBytes }, [10, 20])
+   }
+
+   func testBatchUpdateIgnoresUnknownPaths() async {
+      let store = DownloadStore(savePath: savePath)
+      await store.append(record(path: "a.mp4", received: 1))
+
+      await store.update([record(path: "never-added.mp4", received: 5)])
+
+      let count = await store.list().count
+      XCTAssertEqual(count, 1)
+      XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 1)
+   }
+
+   // MARK: - Total compare-and-set
+
+   func testSetTotalIfChangedReportsOnlyRealChanges() async {
+      let store = DownloadStore(savePath: savePath)
+      let stored = record(path: "a.mp4", total: nil)
+      await store.append(stored)
+      XCTAssertNil(stored.totalBytes)
+
+      let changed = await store.setTotalIfChanged(path: stored.path, total: 2000)
+      XCTAssertEqual(changed?.totalBytes, 2000)
+
+      // Second callback reporting the same total must not report a change.
+      let unchanged = await store.setTotalIfChanged(path: stored.path, total: 2000)
+      XCTAssertNil(unchanged)
+   }
+
+   func testSetTotalIfChangedDoesNotPersist() async throws {
+      let store = DownloadStore(savePath: savePath)
+      let stored = record(path: "a.mp4", total: nil)
+      await store.append(stored)
+      let before = try Data(contentsOf: savePath)
+
+      _ = await store.setTotalIfChanged(path: stored.path, total: 2000)
+
+      // It runs on the hottest callback in the system; pause, cancel and
+      // completion are what write the record.
+      XCTAssertEqual(try Data(contentsOf: savePath), before)
+   }
+
+   // MARK: - Atomic mutation
+
+   func testConcurrentMutationsEachObserveThePreviousOne() async {
+      // Each body runs inside the actor, so every increment sees the one before it.
+      // Composed from findByPath and update, they would land on the same snapshot.
+      let store = DownloadStore(savePath: savePath)
+      let path = URL(fileURLWithPath: "/tmp/a.mp4")
+      let mutations = 200
+
+      await store.append(record(path: "a.mp4"))
+
+      await withTaskGroup(of: Void.self) { group in
+         for _ in 0..<mutations {
+            group.addTask {
+               _ = await store.mutate(path: path, persist: false) { current in
+                  current.setBytes(received: current.receivedBytes + 1, total: current.totalBytes)
+               }
+            }
+         }
+      }
+
+      let updated = await store.findByPath(path)
+
+      XCTAssertEqual(updated?.receivedBytes, UInt64(mutations))
+   }
+
+   func testMutateReturnsTheStoredRecordRatherThanTheCallersSnapshot() async {
+      // What a caller emits must be what the store holds: a pause committed between
+      // two progress callbacks must not be reported as still in progress.
+      let store = DownloadStore(savePath: savePath)
+      let path = URL(fileURLWithPath: "/tmp/a.mp4")
+
+      await store.append(record(path: "a.mp4"))
+      _ = await store.mutate(path: path, persist: false) { $0.setStatus(.inProgress) }
+
+      let paused = await store.mutate(path: path, persist: false) { $0.setStatus(.paused) }
+      let afterProgress = await store.mutate(path: path, persist: false) { current in
+         current.setBytes(received: 500, total: current.totalBytes)
+      }
+
+      let unknown = await store.mutate(path: URL(fileURLWithPath: "/tmp/gone.mp4"), persist: false) {
+         $0.setStatus(.canceled)
+      }
+
+      XCTAssertEqual(paused?.status, .paused)
+      // The byte-only mutation must carry the status the pause left behind.
+      XCTAssertEqual(afterProgress?.status, .paused)
+      XCTAssertEqual(afterProgress?.receivedBytes, 500)
+      XCTAssertNil(unknown)
+   }
+}

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/ProgressTrackerTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/ProgressTrackerTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+@testable import DownloadManagerKit
+
+final class ProgressTrackerTests: XCTestCase {
+
+   // MARK: - Known size
+
+   func testEmitsOnIntegerPercentChange() {
+      // 0.9% — still rounds to percent 0, which is what was last emitted.
+      XCTAssertFalse(ProgressTracker(lastEmittedBytes: 0, receivedBytes: 9, totalBytes: 1000).shouldEmit)
+
+      // 1.0% — crosses into percent 1.
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 0, receivedBytes: 10, totalBytes: 1000).shouldEmit)
+   }
+
+   func testDoesNotEmitWithinTheSamePercent() {
+      // Baseline at 50%: anything still rounding to 50 is nothing new to report.
+      XCTAssertFalse(ProgressTracker(lastEmittedBytes: 500, receivedBytes: 505, totalBytes: 1000).shouldEmit)
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 500, receivedBytes: 510, totalBytes: 1000).shouldEmit)
+   }
+
+   func testAlwaysEmitsAtOneHundredPercent() {
+      // Emits at 100%, and past it if the body overruns the advertised length.
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 990, receivedBytes: 1000, totalBytes: 1000).shouldEmit)
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 1000, receivedBytes: 1000, totalBytes: 1000).shouldEmit)
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 1000, receivedBytes: 1500, totalBytes: 1000).shouldEmit)
+   }
+
+   func testResumingTreatsInitialBytesAsAlreadyEmitted() {
+      // A resumed download must not re-emit the count it started from.
+      XCTAssertFalse(ProgressTracker(lastEmittedBytes: 500, receivedBytes: 500, totalBytes: 1000).shouldEmit)
+   }
+
+   func testIsCompleteWithKnownSize() {
+      XCTAssertFalse(ProgressTracker(lastEmittedBytes: 0, receivedBytes: 999, totalBytes: 1000).isComplete)
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 0, receivedBytes: 1000, totalBytes: 1000).isComplete)
+      XCTAssertTrue(ProgressTracker(lastEmittedBytes: 0, receivedBytes: 1500, totalBytes: 1000).isComplete)
+   }
+
+   func testZeroTotalFallsBackToByteThreshold() {
+      // A zero content length must not divide by zero; treat it as unknown.
+      XCTAssertFalse(ProgressTracker(lastEmittedBytes: 0, receivedBytes: 1, totalBytes: 0).shouldEmit)
+      XCTAssertTrue(
+         ProgressTracker(
+            lastEmittedBytes: 0,
+            receivedBytes: ProgressTracker.bytesThreshold,
+            totalBytes: 0
+         ).shouldEmit
+      )
+
+      // A zero total would otherwise read as complete from the first byte.
+      XCTAssertFalse(
+         ProgressTracker(
+            lastEmittedBytes: 0,
+            receivedBytes: ProgressTracker.bytesThreshold,
+            totalBytes: 0
+         ).isComplete
+      )
+   }
+
+   // MARK: - Unknown size
+
+   func testEmitsEveryThresholdWhenSizeIsUnknown() {
+      XCTAssertFalse(
+         ProgressTracker(
+            lastEmittedBytes: 0,
+            receivedBytes: ProgressTracker.bytesThreshold - 1,
+            totalBytes: nil
+         ).shouldEmit
+      )
+      XCTAssertTrue(
+         ProgressTracker(
+            lastEmittedBytes: 0,
+            receivedBytes: ProgressTracker.bytesThreshold,
+            totalBytes: nil
+         ).shouldEmit
+      )
+   }
+
+   func testUnknownSizeThresholdIsRelativeToTheLastEmission() {
+      XCTAssertFalse(
+         ProgressTracker(
+            lastEmittedBytes: 100,
+            receivedBytes: 100 + ProgressTracker.bytesThreshold - 1,
+            totalBytes: nil
+         ).shouldEmit
+      )
+      XCTAssertTrue(
+         ProgressTracker(
+            lastEmittedBytes: 100,
+            receivedBytes: 100 + ProgressTracker.bytesThreshold,
+            totalBytes: nil
+         ).shouldEmit
+      )
+   }
+
+   func testIsNeverCompleteWhenSizeIsUnknown() {
+      // Unknown-size completion is signalled by the stream ending.
+      XCTAssertFalse(
+         ProgressTracker(
+            lastEmittedBytes: 0,
+            receivedBytes: 10 * ProgressTracker.bytesThreshold,
+            totalBytes: nil
+         ).isComplete
+      )
+   }
+
+   // MARK: - Restarted downloads
+
+   func testRestartFromZeroEmitsImmediately() {
+      // URLSession restarts from zero when resume data is rejected, so the
+      // cumulative count can come back below the store's baseline. Emitting
+      // resets it; staying quiet would strand the frontend on a stale count.
+      // The unknown-size branch also subtracts, so this guards underflow.
+      XCTAssertTrue(
+         ProgressTracker(lastEmittedBytes: 5_000_000, receivedBytes: 65_536, totalBytes: nil).shouldEmit
+      )
+      XCTAssertTrue(
+         ProgressTracker(lastEmittedBytes: 900, receivedBytes: 10, totalBytes: 1000).shouldEmit
+      )
+   }
+
+   func testNormalThrottlingResumesOnceTheBaselineHasReset() {
+      // Once the lower count is emitted it becomes the baseline.
+      XCTAssertFalse(
+         ProgressTracker(lastEmittedBytes: 65_536, receivedBytes: 65_536, totalBytes: nil).shouldEmit
+      )
+      XCTAssertTrue(
+         ProgressTracker(
+            lastEmittedBytes: 65_536,
+            receivedBytes: 65_536 + ProgressTracker.bytesThreshold,
+            totalBytes: nil
+         ).shouldEmit
+      )
+   }
+}

--- a/ios/Sources/DownloadPlugin.swift
+++ b/ios/Sources/DownloadPlugin.swift
@@ -22,7 +22,7 @@ class DownloadPlugin: Plugin {
           for await download in DownloadManager.shared.changed {
              try? self.trigger("changed", data: download);
 #if DEBUG
-             Logger.debug("[\(download.path)] \(download.status) - \(String(format: "%.0f", download.progress))%")
+             Logger.debug("[\(download.path.lastPathComponent)] \(download.status) - \(String(format: "%.0f", download.progress))% (\(download.receivedBytes)/\(download.totalBytes.map { String($0) } ?? "unknown") bytes)")
 #endif
           }
       }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,6 +24,7 @@ function buildConfig(input, output) {
          typescript({
             declaration: true,
             declarationDir: dirname(output.import),
+            exclude: [ '**/*.test.ts' ],
          }),
       ],
       external: [


### PR DESCRIPTION
Closes https://github.com/silvermine/tauri-plugin-download/issues/46

## Summary

Download events now carry the byte counts alongside the progress percentage, so a consumer never has to synthesize them and the plugin stays the source of truth.

`receivedBytes` and `totalBytes` are already declared in the frontend contract (`guest-js/types.ts`) and already reported by the desktop (Rust) implementation, but the mobile managers never populated them — a mobile download could only report a percentage, and reported `0%` for the whole transfer when the server sent no content length. This brings iOS and Android to parity.

The core change is splitting the one type that was doing two jobs:

- **`DownloadRecord`** — persisted to `downloads.json`, internal. Holds the byte counts and (on iOS) the resume-data path. Never reaches the frontend.
- **`DownloadItem`** — emit-only payload. Built from a record, with `progress` derived from `receivedBytes` / `totalBytes` rather than stored.

This mirrors the split already present in `crates/download-manager/src/models.rs`, so all three platforms now agree on both the payload shape and where progress is computed.

## Changes

**Byte counts**

- `totalBytes` is `null` when the server supplies no content length, rather than collapsing to a bogus `0`. Serialized as an explicit JSON `null`, not an absent key.
- `DownloadRecord.withBytes` / `setBytes` cannot narrow a known total. A `null` total means "this response did not report one", not "there is none", so a chunked resume no longer erases a length an earlier response established.
- Both platforms gain a `ProgressTracker` mirroring the Rust emission rule: emit on each integer-percent change when the total is known, otherwise every 1 MiB. `isComplete()` requires a *positive* total, and Android clamps the `Content-Length` sum, so a wrapped or hostile header cannot make a download read as complete from its first byte.
- Android's notification goes indeterminate when the total is unknown.

**Reliability**

- **iOS gains reconcile-on-init.** `start()` and `resume()` both commit `inProgress` before starting the task, so a process death in that window left a record that neither would accept afterwards. Reconciliation now reverts such records — but only where the session reports no live task, since background-session tasks outlive the process and a blind revert would clobber a download that is genuinely still running.
- **`resume()` keeps its resume-data file until the task is actually running.** Deleting it before `task.resume()` meant a death in that window lost the partial download outright rather than leaving it resumable.
- **The `InProgress` revert rule is written once.** `DownloadManager.revertInProgress` (Android) and `reconciledRecord` (iOS) are pure decisions; reconciliation and the worker's early-stop and transient-error paths all defer to them. Two side effects worth noting: the transient-error path now leaves a record alone if it is no longer `InProgress` (previously it overwrote a concurrent `pause()`), and with no temp file it yields `Idle` at zero rather than a `Paused` record with nothing to resume from.
- **The newly-learned total is recorded in a single actor hop** on iOS (`DownloadStore.setTotalIfChanged`) and no longer writes the whole store file from the progress callback.
- **Reconciliation writes the store once**, not once per reverted record.

**Examples**

- SwiftUI, Compose, and the Vue example app all display received/total bytes.

## Testing

CI is green. Swift 50 tests, Kotlin 45, including these new suites:

- `DownloadRecordTest` / `DownloadRecordTests` — progress derivation, including the unknown-total and completed cases, and that `DownloadItem` encodes exactly the six contract keys (it hand-writes `encode(to:)`, so a field added without an encode line would silently vanish on iOS only).
- `ProgressTrackerTest` / `ProgressTrackerTests` — the emission rule on the known-size and unknown-size paths.
- `DownloadManagerTest` / `DownloadManagerTests` — the reconcile decision on both platforms: live task left alone, resume data present versus absent, and every non-`InProgress` status untouched.
- `DownloadStoreTest` / `DownloadStoreTests` — load, persist, `persist: false` leaving the file byte-identical, batched updates, and the total compare-and-set. The Android store's decode is extracted to a pure, log-free function and the iOS store takes an injectable path, so both are testable without a device.

Not yet exercised on a device. The iOS reconcile has only been tested through its pure decision function — its behaviour against a real restored background session is worth a manual pass, and so is the notification cadence on Android.

## Deliberately not here

One malformed record in `downloads.json` still discards every record in the file, on all three platforms. That is tracked in #64 — it changes persistence recovery behaviour and deserves its own review rather than riding along with the byte-count work. Both platforms have a test pinning today's behaviour, commented to be inverted when #64 lands.
