### PR TITLE
feat: enforce the download network policy on iOS and Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Thumbs.db
 
 # Tauri
 /gen/
+.tauri/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ tracing = { version = "0.1.41", default-features = false, features = ["std", "lo
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 tauri-plugin = { version = "2.5.1", features = ["build"] }
+
+[dev-dependencies]
+serde_json = "1.0.145"

--- a/README.md
+++ b/README.md
@@ -213,20 +213,30 @@ Only mobile has an OS scheduler to defer to, so desktop refuses where mobile wai
 | --- | --- | --- |
 | Desktop | Rejects; the download stays `Idle` or `Paused` to retry later. | Keeps running. |
 | iOS | Resolves, status `InProgress`; the background `URLSession` task waits, transferring nothing. | Stalls, then continues on its own. |
-| Android | Resolves, status `InProgress`; WorkManager holds the work request. | Stops. Whether it resumes on its own is a race — see below. |
+| Android | Resolves, status `InProgress`; WorkManager holds the work request. | Stalls, then continues on its own — see below. |
 
-Android is the row to plan for. Two paths can observe the network change, and they
-differ in the one way that matters:
+Neither platform needs a call from you to recover, but they differ. iOS leaves the task
+alone and it continues when a network satisfies it. Android's worker cannot survive the
+connection going away, so WorkManager retries it on the same constraint, resuming from
+the partial file — expect it to lag by the backoff delay rather than restarting the
+moment the network qualifies.
 
-   * WorkManager's constraint tracker stops the worker — it re-runs by itself once the
-     network qualifies again.
-   * The connection drops out from under the transfer first — the worker reports
-     failure, WorkManager does not retry, and the download waits for a `resume()`.
+Two caveats on Android. If the constraint tracker stops the worker before the connection
+drops — the two race — the download reports `Paused` before the retry moves it back to
+`InProgress`.
 
-Both revert to `Paused`, or to `Idle` if nothing had reached disk yet. So a restricted
-download may move between `Paused` and `InProgress` with no call from you, and may
-equally sit there waiting for one: never read `Paused` as "the user paused it", and
-never rely on an automatic resume.
+The same happens while work is merely waiting, which is ordinary rather than a race: a
+record held on the unmetered constraint or in a retry backoff stays `InProgress` with no
+worker running. Restart the app then and the plugin reconciles it to `Paused`, or `Idle`
+at zero bytes when no partial file survives, before the pending work moves it back.
+Reconciliation emits no event, so the stale value arrives through the next `get()` or
+`list()`.
+
+So treat `Paused` and `Idle` as "not currently transferring" rather than "waiting for the
+user", and drive recovery off events. No bytes are lost either way. Constraint holds are
+not time-limited; transient errors are. A download gives up after at most five retries —
+fewer if constraint interruptions have spent part of the same budget — then needs
+`resume()`, or `start()` if it reconciled to `Idle`.
 
 > Resuming an iOS download goes through `downloadTask(withResumeData:)`, which takes no
 > request, so the policy is inherited from the original task rather than reapplied. That

--- a/README.md
+++ b/README.md
@@ -186,8 +186,7 @@ async function manageDownload() {
 }
 ```
 
-On desktop, a download can be restricted to unmetered, unconstrained networks when it
-is created:
+A download can be restricted to unmetered, unconstrained networks when it is created:
 
 ```ts
 const download = await get('/path/to/large-file.zip');
@@ -202,12 +201,37 @@ if (download.status === DownloadStatus.Pending) {
 }
 ```
 
-`allowMetered` defaults to `true`. When it is `false`, both `start()` and `resume()`
-reject if there is no active connection, connectivity cannot be determined, or the
-current connection is reported as metered or constrained. The stored download remains
-idle or paused so the action can be retried later. A connection change does not stop a
-download that is already in progress. Android and iOS currently accept this option but
-do not enforce it.
+`allowMetered` defaults to `true`. When it is `false`, the download is confined to
+connections the platform reports as unmetered — no cellular, no personal hotspot.
+Desktop and iOS also exclude constrained connections (Low Data Mode on iOS); Android
+has no equivalent, so there the option maps to WorkManager's unmetered constraint
+alone.
+
+Only mobile has an OS scheduler to defer to, so desktop refuses where mobile waits:
+
+| | No eligible network at `start()`/`resume()` | Network stops qualifying mid-transfer |
+| --- | --- | --- |
+| Desktop | Rejects; the download stays `Idle` or `Paused` to retry later. | Keeps running. |
+| iOS | Resolves, status `InProgress`; the background `URLSession` task waits, transferring nothing. | Stalls, then continues on its own. |
+| Android | Resolves, status `InProgress`; WorkManager holds the work request. | Stops. Whether it resumes on its own is a race — see below. |
+
+Android is the row to plan for. Two paths can observe the network change, and they
+differ in the one way that matters:
+
+   * WorkManager's constraint tracker stops the worker — it re-runs by itself once the
+     network qualifies again.
+   * The connection drops out from under the transfer first — the worker reports
+     failure, WorkManager does not retry, and the download waits for a `resume()`.
+
+Both revert to `Paused`, or to `Idle` if nothing had reached disk yet. So a restricted
+download may move between `Paused` and `InProgress` with no call from you, and may
+equally sit there waiting for one: never read `Paused` as "the user paused it", and
+never rely on an automatic resume.
+
+> Resuming an iOS download goes through `downloadTask(withResumeData:)`, which takes no
+> request, so the policy is inherited from the original task rather than reapplied. That
+> it survives is confirmed on device, but Apple does not document resume data as carrying
+> request properties — worth re-checking against new iOS releases.
 
 The network policy is fixed when the download is first created. Every download state
 exposes its resolved policy through `download.options.allowMetered`. Calling `create()`

--- a/README.md
+++ b/README.md
@@ -407,6 +407,18 @@ The `android/` directory is a 3-module Gradle build:
 Open the `android/` directory in Android Studio, select the `:example` run configuration,
 and run on an emulator or device.
 
+### Testing the Network Policy
+
+No SIM is needed: mark the Wi-Fi network as metered from its settings page — under
+Network & internet on stock Android, Connections on One UI — where the option reads
+"Treat as metered" or "Metered". The
+example app's "Allow metered networks" toggle sets `allowMetered` on the downloads it
+creates, and each row shows the policy it was created with.
+
+With the toggle off, a download started on a metered network holds at zero bytes and
+begins once the network is marked unmetered. Marking the network metered mid-transfer
+stalls it, and it continues by itself a backoff delay later.
+
 ## iOS Support
 
 On iOS, this plugin uses `URLSession` with a background configuration, which allows
@@ -425,6 +437,23 @@ to continue even when the app is suspended or terminated by the system.
 
 Open `ios/DownloadManagerExample/DownloadManagerExample.xcodeproj` in Xcode,
 select a simulator or device, and run.
+
+### Testing the Network Policy
+
+No SIM is needed, but a real device is: Low Data Mode cannot be set on a simulator.
+Toggle it under Settings → Wi-Fi → the ⓘ beside your network → Low Data Mode, which
+trips `allowsConstrainedNetworkAccess`. The example app's "Allow metered networks"
+toggle sets `allowMetered` on the downloads it creates, and each row shows the policy
+it was created with.
+
+With the toggle off, a download started in Low Data Mode holds at zero bytes and
+begins once Low Data Mode is off. Turning it on mid-transfer stalls the download
+without leaving `inProgress`, and it continues by itself once it is off again.
+
+Worth repeating on new iOS majors: pause a restricted download, turn Low Data Mode on,
+then resume. It should stay stalled. Resuming goes through
+`downloadTask(withResumeData:)`, which carries the policy in undocumented resume data,
+so this is the check that catches a silent regression there.
 
 ### Tauri Apps
 

--- a/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsScreen.kt
+++ b/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsScreen.kt
@@ -90,6 +90,20 @@ fun DownloadsScreen(viewModel: DownloadsViewModel = viewModel()) {
             )
          }
 
+         // Fixed on the download at creation. Turn this off and WorkManager holds
+         // the transfer until the device is on an unmetered network.
+         Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(bottom = 8.dp),
+         ) {
+            Text("Allow metered networks")
+            Switch(
+               checked = state.allowMetered,
+               onCheckedChange = viewModel::updateAllowMetered,
+            )
+         }
+
          LazyColumn(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.fillMaxSize(),
@@ -168,6 +182,12 @@ private fun DownloadRow(
       // total is not always known even while bytes are arriving.
       Text(
          text = "${formatBytes(item.receivedBytes)} / ${item.totalBytes?.let { formatBytes(it) } ?: "unknown"}",
+         style = MaterialTheme.typography.bodySmall,
+         color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+
+      Text(
+         text = if (item.options.allowMetered) "Metered: allowed" else "Metered: blocked",
          style = MaterialTheme.typography.bodySmall,
          color = MaterialTheme.colorScheme.onSurfaceVariant,
       )

--- a/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsViewModel.kt
+++ b/android/example/src/main/java/org/silvermine/downloadmanager/example/DownloadsViewModel.kt
@@ -3,6 +3,7 @@ package org.silvermine.downloadmanager.example
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import org.silvermine.downloadmanager.CreateOptions
 import org.silvermine.downloadmanager.DownloadItem
 import org.silvermine.downloadmanager.DownloadManager
 import org.silvermine.downloadmanager.DownloadStatus
@@ -15,6 +16,7 @@ import java.io.File
 data class PendingDownload(
    val url: String,
    val path: String,
+   val options: CreateOptions,
 )
 
 data class DownloadsUiState(
@@ -22,6 +24,7 @@ data class DownloadsUiState(
    val pendingDownloads: List<PendingDownload> = emptyList(),
    val downloadURL: String = "",
    val autoCreate: Boolean = true,
+   val allowMetered: Boolean = true,
 )
 
 class DownloadsViewModel(application: Application) : AndroidViewModel(application) {
@@ -53,6 +56,10 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
       _uiState.value = _uiState.value.copy(autoCreate = autoCreate)
    }
 
+   fun updateAllowMetered(allowMetered: Boolean) {
+      _uiState.value = _uiState.value.copy(allowMetered = allowMetered)
+   }
+
    fun getDownload() {
       val state = _uiState.value
       val url = state.downloadURL.trim()
@@ -71,9 +78,11 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
 
       val download = manager.get(path)
 
+      val options = CreateOptions(allowMetered = state.allowMetered)
+
       if (download.status == DownloadStatus.Pending) {
          if (state.autoCreate) {
-            manager.create(path, url)
+            manager.create(path, url, options)
             _uiState.value = _uiState.value.copy(
                downloadURL = "",
                downloads = manager.list(),
@@ -81,7 +90,8 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
          } else {
             _uiState.value = _uiState.value.copy(
                downloadURL = "",
-               pendingDownloads = state.pendingDownloads + PendingDownload(url = url, path = path),
+               pendingDownloads = state.pendingDownloads +
+                  PendingDownload(url = url, path = path, options = options),
             )
          }
       } else {
@@ -90,7 +100,7 @@ class DownloadsViewModel(application: Application) : AndroidViewModel(applicatio
    }
 
    fun createDownload(pending: PendingDownload) {
-      manager.create(pending.path, pending.url)
+      manager.create(pending.path, pending.url, pending.options)
       _uiState.value = _uiState.value.copy(
          pendingDownloads = _uiState.value.pendingDownloads.filter { it.path != pending.path },
          downloads = manager.list(),

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/CreateOptions.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/CreateOptions.kt
@@ -1,0 +1,24 @@
+package org.silvermine.downloadmanager
+
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Options fixed when a download is created: calling [DownloadManager.create] again
+ * for an existing path returns the stored record with its original options.
+ *
+ * Mirrors the Rust `CreateOptions` in `crates/download-manager/src/models.rs`.
+ *
+ * @property allowMetered Whether the download may transfer on metered connections.
+ *    When `false` the work request requires [androidx.work.NetworkType.UNMETERED], so
+ *    WorkManager holds the download rather than failing it. The default is what
+ *    [DownloadManager.create] applies when a caller states none; [Required] settles it
+ *    on the wire both ways — always encoded, never defaulted on decode.
+ */
+@Serializable
+data class CreateOptions(
+   @Required
+   @SerialName("allowMetered")
+   val allowMetered: Boolean = true,
+)

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadItem.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadItem.kt
@@ -13,8 +13,7 @@ import kotlinx.serialization.Serializable
  * No property carries a default, so every key here is written whatever
  * `encodeDefaults` the caller's `Json` uses, rather than depending on the
  * TypeScript layer to coalesce it (attachDownload in `guest-js/actions.ts`).
- * `options` is the one field of `DownloadState` mobile does not emit — the
- * desktop payload carries it, and the TypeScript layer supplies the default.
+ * [CreateOptions] carries one but marks it `@Required`, so it is written too.
  */
 @Serializable
 data class DownloadItem(
@@ -23,6 +22,10 @@ data class DownloadItem(
 
    @SerialName("path")
    val path: String,
+
+   /** Network policy fixed when this download was created. */
+   @SerialName("options")
+   val options: CreateOptions,
 
    @SerialName("receivedBytes")
    val receivedBytes: Long,

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
@@ -89,18 +89,26 @@ class DownloadManager private constructor(context: Context) {
    /**
     * Creates a download operation.
     *
+    * Options are fixed on creation: an existing record is returned unchanged,
+    * keeping its original options, as on desktop.
+    *
     * @param path The download path.
     * @param url The download URL for the resource.
+    * @param options Network policy persisted with the download.
     * @return The download action response.
     */
    @Synchronized
-   fun create(path: String, url: String): DownloadActionResponse {
+   fun create(
+      path: String,
+      url: String,
+      options: CreateOptions = CreateOptions(),
+   ): DownloadActionResponse {
       val existing = store.findByPath(path)
       if (existing != null) {
          return DownloadActionResponse.withExpectedStatus(existing.toItem(), DownloadStatus.Idle)
       }
 
-      val record = DownloadRecord(url = url, path = path)
+      val record = DownloadRecord(url = url, path = path, options = options)
       store.append(record)
 
       return DownloadActionResponse.new(emitChanged(record))
@@ -233,12 +241,8 @@ class DownloadManager private constructor(context: Context) {
     * Uses unique work keyed by path to prevent duplicate workers.
     */
    private fun enqueueDownload(record: DownloadRecord) {
-      val constraints = Constraints.Builder()
-         .setRequiredNetworkType(NetworkType.CONNECTED)
-         .build()
-
       val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
-         .setConstraints(constraints)
+         .setConstraints(constraintsFor(record.options))
          .setInputData(
             workDataOf(
                DownloadWorker.KEY_URL to record.url,
@@ -259,14 +263,31 @@ class DownloadManager private constructor(context: Context) {
 
    companion object {
       /**
-       * Decides what a record left `InProgress` with no worker behind it should
-       * become. Returns `null` when the record needs no change.
+       * Builds the work request's constraints from a download's network policy.
        *
-       * A worker can stop without clearing the status — process death, WorkManager
-       * cancelling it, a transient error after its retries. The temp file is the
-       * only honest account of what survived: only bytes flushed to disk are
-       * resumable, whatever the last progress tick reported. With no temp file
-       * there is nothing to resume from, so the download restarts from scratch.
+       * [NetworkType.UNMETERED] holds a restricted download rather than failing it,
+       * and stops then re-runs a worker whose network stops qualifying. That leaves
+       * the record Paused in between (see [DownloadWorker]), so a restricted download
+       * can move between Paused and InProgress without the caller asking.
+       *
+       * Built here rather than inline in [enqueueDownload], which needs a Context and
+       * so cannot be reached from a JVM test.
+       */
+      internal fun constraintsFor(options: CreateOptions): Constraints =
+         Constraints.Builder()
+            .setRequiredNetworkType(
+               if (options.allowMetered) NetworkType.CONNECTED else NetworkType.UNMETERED
+            )
+            .build()
+
+      /**
+       * Decides what a record left `InProgress` with no worker behind it should
+       * become, or `null` when it needs no change.
+       *
+       * A worker can stop without clearing the status — process death, cancellation,
+       * a transient error out of retries. The temp file is the only honest account of
+       * what survived: only flushed bytes are resumable, and with none the download
+       * restarts from scratch.
        *
        * Mirrors `Manager::revert_in_progress` in
        * `crates/download-manager/src/manager.rs`, kept pure so it can be tested

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadRecord.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadRecord.kt
@@ -1,5 +1,6 @@
 package org.silvermine.downloadmanager
 
+import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -17,6 +18,10 @@ internal data class DownloadRecord(
 
    @SerialName("path")
    val path: String,
+
+   @Required
+   @SerialName("options")
+   val options: CreateOptions = CreateOptions(),
 
    @SerialName("receivedBytes")
    val receivedBytes: Long = 0L,
@@ -58,6 +63,7 @@ internal data class DownloadRecord(
       return DownloadItem(
          url = url,
          path = path,
+         options = options,
          receivedBytes = receivedBytes,
          totalBytes = totalBytes,
          progress = progress,

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadRecord.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadRecord.kt
@@ -23,6 +23,7 @@ internal data class DownloadRecord(
    @SerialName("options")
    val options: CreateOptions = CreateOptions(),
 
+   @Required
    @SerialName("receivedBytes")
    val receivedBytes: Long = 0L,
 
@@ -30,6 +31,7 @@ internal data class DownloadRecord(
    @SerialName("totalBytes")
    val totalBytes: Long? = null,
 
+   @Required
    @SerialName("status")
    val status: DownloadStatus = DownloadStatus.Idle,
 ) {

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
@@ -247,7 +247,7 @@ internal class DownloadWorker(
 
    /**
     * Reverts a record still marked InProgress when this worker stops early —
-    * either stopped externally, or out of retries on a transient error.
+    * either stopped externally, or out of WorkManager attempts on a transient error.
     *
     * A pause cancels the WorkManager work and sets the record to Paused, but the
     * worker may already have written InProgress back before observing isStopped.
@@ -293,17 +293,28 @@ internal class DownloadWorker(
 
    /**
     * Handles transient failures (network drops, timeouts that exhausted retries).
-    * Preserves the temp file and transitions to Paused so the download can be
-    * resumed later via Range headers. Mirrors iOS behavior where URLSession saves
-    * resume data for transient errors.
+    * Preserves the temp file and retries, resuming via Range headers once the work's
+    * constraints allow.
+    *
+    * The record stays InProgress while attempts remain — a retry is a worker behind it,
+    * and Paused would tell the caller to resume something already queued. The cap
+    * catches downloads failing for their own reasons, not just the network-policy stall
+    * it was written for. It counts runs, not errors: waiting on a constraint is free,
+    * but every start costs an attempt.
     */
    private fun handleTransientError(manager: DownloadManager, store: DownloadStore, path: String, message: String): Result {
-      Log.w(TAG, "Download failed (transient) for $path: $message")
+      if (isOutOfAttempts(runAttemptCount)) {
+         Log.w(TAG, "Download failed (transient, out of attempts) for $path: $message")
+         revertInProgressRecord(manager, store, path)
+         dismissNotification()
 
-      revertInProgressRecord(manager, store, path)
+         return Result.failure()
+      }
 
+      Log.w(TAG, "Download stalled (transient) for $path: $message")
       dismissNotification()
-      return Result.failure()
+
+      return Result.retry()
    }
 
    private fun notificationID(): Int = id.hashCode()
@@ -392,6 +403,12 @@ internal class DownloadWorker(
       internal const val DOWNLOAD_SUFFIX = ".download"
       private const val BUFFER_SIZE = 64 * 1024
       private const val MAX_RETRIES = 3
+
+      /**
+       * Five retries on WorkManager's default 30-second exponential backoff — relied
+       * on here rather than set — is roughly a quarter hour.
+       */
+      private const val MAX_WORK_ATTEMPTS = 5
       private const val NOTIFICATION_CHANNEL_ID = "download_manager_channel"
 
       /**
@@ -404,6 +421,15 @@ internal class DownloadWorker(
          val tempFile = File("$path$DOWNLOAD_SUFFIX")
          return if (tempFile.exists()) tempFile.length() else null
       }
+
+      /**
+       * Whether a transient failure has run out of retries and should give up.
+       *
+       * WorkManager counts the runs before this one, so the first sees 0 and the
+       * download gives up on the run that sees [MAX_WORK_ATTEMPTS].
+       */
+      internal fun isOutOfAttempts(runAttemptCount: Int): Boolean =
+         runAttemptCount >= MAX_WORK_ATTEMPTS
 
       private fun isTransient(e: IOException): Boolean = when (e) {
          is UnknownHostException -> false  // DNS resolution failed

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
@@ -1,5 +1,6 @@
 package org.silvermine.downloadmanager
 
+import androidx.work.NetworkType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
@@ -57,5 +58,28 @@ class DownloadManagerTest {
          assertNull("$status should not be reverted", DownloadManager.revertInProgress(record, 480L))
          assertNull("$status should not be reverted", DownloadManager.revertInProgress(record, null))
       }
+   }
+
+   // -- Network policy --
+
+   // Building the Constraints outside enqueueDownload() shrinks the untestable surface
+   // to one delegating call. That delegation stays uncovered — enqueueDownload() needs a
+   // Context — so these pin the policy the constraint carries, not that the enqueue path
+   // uses it.
+
+   @Test
+   fun `an unrestricted download only requires a connection`() {
+      assertEquals(
+         NetworkType.CONNECTED,
+         DownloadManager.constraintsFor(CreateOptions(allowMetered = true)).requiredNetworkType,
+      )
+   }
+
+   @Test
+   fun `a restricted download requires an unmetered network`() {
+      assertEquals(
+         NetworkType.UNMETERED,
+         DownloadManager.constraintsFor(CreateOptions(allowMetered = false)).requiredNetworkType,
+      )
    }
 }

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadRecordTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadRecordTest.kt
@@ -4,8 +4,10 @@ import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlinx.serialization.SerializationException
 
 class DownloadRecordTest {
 
@@ -139,6 +141,7 @@ class DownloadRecordTest {
       // field names drifted on both sides together.
       val encoded = """
          {"url":"http://example.com/f.mp4","path":"/tmp/f.mp4",
+         "options":{"allowMetered":true},
          "receivedBytes":500,"totalBytes":1000,"status":"paused"}
       """.trimIndent()
 
@@ -164,6 +167,88 @@ class DownloadRecordTest {
       assertEquals(DownloadStatus.Paused, decoded.status)
       // progress is derived via toItem(), not stored.
       assertEquals(50.0, decoded.toItem().progress, 0.0)
+   }
+
+
+   // -- Network policy --
+
+   @Test
+   fun `an unstated policy allows metered connections`() {
+      // The API default, applied when a caller states no policy. @Required keeps
+      // that default off the wire: a persisted record always states the value.
+      assertTrue(sampleRecord().options.allowMetered)
+      assertTrue(CreateOptions().allowMetered)
+   }
+
+   @Test
+   fun `record without options fails to decode`() {
+      // The policy is decided once, at creation. A record that has lost it cannot
+      // be read back as anything trustworthy, so decoding refuses rather than
+      // assuming the permissive default.
+      val encoded = """
+         {"url":"http://example.com/f.mp4","path":"/tmp/f.mp4",
+         "receivedBytes":0,"totalBytes":null,"status":"idle"}
+      """.trimIndent()
+
+      assertThrows(SerializationException::class.java) {
+         json.decodeFromString(DownloadRecord.serializer(), encoded)
+      }
+   }
+
+   @Test
+   fun `record with empty options fails to decode`() {
+      val encoded = """
+         {"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","options":{},
+         "receivedBytes":0,"totalBytes":null,"status":"idle"}
+      """.trimIndent()
+
+      assertThrows(SerializationException::class.java) {
+         json.decodeFromString(DownloadRecord.serializer(), encoded)
+      }
+   }
+
+   @Test
+   fun `record decodes a restricted policy`() {
+      val encoded = """
+         {"url":"http://example.com/f.mp4","path":"/tmp/f.mp4",
+         "options":{"allowMetered":false},
+         "receivedBytes":0,"totalBytes":null,"status":"idle"}
+      """.trimIndent()
+
+      val record = json.decodeFromString(DownloadRecord.serializer(), encoded)
+
+      assertFalse(record.options.allowMetered)
+   }
+
+   @Test
+   fun `record round trips a restricted policy`() {
+      val record = sampleRecord().copy(options = CreateOptions(allowMetered = false))
+      val decoded = json.decodeFromString(
+         DownloadRecord.serializer(),
+         json.encodeToString(DownloadRecord.serializer(), record),
+      )
+
+      assertFalse(decoded.options.allowMetered)
+   }
+
+   @Test
+   fun `item carries the resolved policy`() {
+      val item = sampleRecord().copy(options = CreateOptions(allowMetered = false)).toItem()
+
+      assertFalse(item.options.allowMetered)
+
+      // The bridge encodes with encodeDefaults = true so allowMetered is explicit
+      // inside the options object rather than left to the TypeScript fallback.
+      val encoded = json.encodeToString(DownloadItem.serializer(), item)
+      assertTrue(encoded.contains("\"options\":{\"allowMetered\":false}"))
+   }
+
+   @Test
+   fun `item always writes the options key`() {
+      // DownloadItem carries no defaults, so every key survives a default encoder.
+      val encoded = defaultJson.encodeToString(DownloadItem.serializer(), sampleRecord().toItem())
+
+      assertTrue(encoded.contains("\"options\""))
    }
 
    // -- Action response --

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadStoreTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadStoreTest.kt
@@ -79,12 +79,24 @@ class DownloadStoreTest {
    }
 
    @Test
-   fun `absent byte fields fall back to their defaults`() {
+   fun `a record without received bytes fails to decode`() {
+      // Matches the Rust and Swift records: everything but totalBytes is stated.
+      assertThrows(SerializationException::class.java) {
+         DownloadStore.decodeRecords(
+            """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"status":"idle"}]"""
+         )
+      }
+   }
+
+   @Test
+   fun `an omitted total is decoded as null`() {
+      // totalBytes stays optional on all three platforms: absent means the server
+      // reported no content length.
       val decoded = DownloadStore.decodeRecords(
-         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"status":"idle"}]"""
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":7,"status":"idle"}]"""
       )
 
-      assertEquals(0L, decoded.first().receivedBytes)
+      assertEquals(7L, decoded.first().receivedBytes)
       assertNull(decoded.first().totalBytes)
    }
 
@@ -116,18 +128,19 @@ class DownloadStoreTest {
 
    @Test
    fun `a record of every default survives the round trip`() {
-      // The store's Json leaves encodeDefaults off, so a default-valued record
-      // persists as url and path alone — the shape production actually writes.
+      // The store's Json leaves encodeDefaults off, so only @Required properties
+      // survive it — the shape production actually writes. totalBytes is the one
+      // field that may legitimately be absent, so it alone is dropped.
       val record = DownloadRecord(url = "http://example.com/a.mp4", path = "/tmp/a.mp4")
 
       val encoded = DownloadStore.encodeRecords(listOf(record))
       val decoded = DownloadStore.decodeRecords(encoded)
 
-      assertFalse(encoded.contains("receivedBytes"))
-      // options is @Required, so it survives an encoder that drops defaults.
       assertTrue(encoded.contains(""""options":{"allowMetered":true}"""))
+      assertTrue(encoded.contains(""""receivedBytes":0"""))
+      assertTrue(encoded.contains(""""status":"idle"""))
+      assertFalse(encoded.contains("totalBytes"))
       assertEquals(listOf(record), decoded)
-      assertEquals(0L, decoded.first().receivedBytes)
       assertNull(decoded.first().totalBytes)
    }
 }

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadStoreTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadStoreTest.kt
@@ -3,6 +3,7 @@ package org.silvermine.downloadmanager
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertThrows
 import kotlinx.serialization.SerializationException
 import org.junit.Test
@@ -30,7 +31,7 @@ class DownloadStoreTest {
    @Test
    fun `decodes persisted records`() {
       val decoded = DownloadStore.decodeRecords(
-         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","receivedBytes":500,"totalBytes":1000,"status":"paused"}]"""
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":500,"totalBytes":1000,"status":"paused"}]"""
       )
 
       assertEquals(1, decoded.size)
@@ -51,9 +52,9 @@ class DownloadStoreTest {
       assertThrows(SerializationException::class.java) {
          DownloadStore.decodeRecords(
             """
-            [{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","receivedBytes":1,"status":"paused"},
+            [{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":1,"status":"paused"},
              {"url":"http://example.com/b.mp4","status":"paused"},
-             {"url":"http://example.com/c.mp4","path":"/tmp/c.mp4","receivedBytes":3,"status":"idle"}]
+             {"url":"http://example.com/c.mp4","path":"/tmp/c.mp4","options":{"allowMetered":true},"receivedBytes":3,"status":"idle"}]
             """.trimIndent()
          )
       }
@@ -71,7 +72,7 @@ class DownloadStoreTest {
       // The store's Json is configured with ignoreUnknownKeys, so a field added by
       // a later version does not cost the record.
       val decoded = DownloadStore.decodeRecords(
-         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","receivedBytes":7,"status":"idle","somethingNew":42}]"""
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":7,"status":"idle","somethingNew":42}]"""
       )
 
       assertEquals(7L, decoded.first().receivedBytes)
@@ -80,7 +81,7 @@ class DownloadStoreTest {
    @Test
    fun `absent byte fields fall back to their defaults`() {
       val decoded = DownloadStore.decodeRecords(
-         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","status":"idle"}]"""
+         """[{"url":"http://example.com/a.mp4","path":"/tmp/a.mp4","options":{"allowMetered":true},"status":"idle"}]"""
       )
 
       assertEquals(0L, decoded.first().receivedBytes)
@@ -123,6 +124,8 @@ class DownloadStoreTest {
       val decoded = DownloadStore.decodeRecords(encoded)
 
       assertFalse(encoded.contains("receivedBytes"))
+      // options is @Required, so it survives an encoder that drops defaults.
+      assertTrue(encoded.contains(""""options":{"allowMetered":true}"""))
       assertEquals(listOf(record), decoded)
       assertEquals(0L, decoded.first().receivedBytes)
       assertNull(decoded.first().totalBytes)

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadWorkerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadWorkerTest.kt
@@ -1,0 +1,31 @@
+package org.silvermine.downloadmanager
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadWorkerTest {
+
+   // These pin the predicate, not the branches it drives: a CoroutineWorker cannot be
+   // built without WorkManager's test artifact, so neither path in handleTransientError
+   // is covered here. WorkManager counts the runs before the current one, so a
+   // download's first run sees 0.
+
+   @Test
+   fun `a download has attempts left up to the cap`() {
+      for (runAttemptCount in 0..4) {
+         assertFalse(
+            "run reporting $runAttemptCount should still have attempts",
+            DownloadWorker.isOutOfAttempts(runAttemptCount),
+         )
+      }
+   }
+
+   @Test
+   fun `a download is out of attempts once five are spent`() {
+      // Above the cap is reachable, not merely defensive: a constraint interruption
+      // increments the count without ever consulting the cap.
+      assertTrue(DownloadWorker.isOutOfAttempts(5))
+      assertTrue(DownloadWorker.isOutOfAttempts(6))
+   }
+}

--- a/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
+++ b/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
@@ -9,6 +9,7 @@ import app.tauri.annotation.TauriPlugin
 import app.tauri.plugin.Invoke
 import app.tauri.plugin.JSObject
 import app.tauri.plugin.Plugin
+import org.silvermine.downloadmanager.CreateOptions
 import org.silvermine.downloadmanager.DownloadManager
 import org.silvermine.downloadmanager.parsePath
 import org.silvermine.downloadmanager.parseURI
@@ -28,10 +29,23 @@ class PathArgs {
    var path: String? = null
 }
 
+/**
+ * Bridge-local mirror of [CreateOptions], kept separate so Tauri's `@InvokeArg`
+ * reflection and kotlinx.serialization never share a type.
+ *
+ * Nullable so an absent value is rejected rather than defaulted. The Rust bridge
+ * resolves the API default before invoking, so the policy always arrives stated.
+ */
+@InvokeArg
+class CreateOptionsArgs {
+   var allowMetered: Boolean? = null
+}
+
 @InvokeArg
 class CreateArgs {
    var path: String? = null
    var url: String? = null
+   var options: CreateOptionsArgs? = null
 }
 
 @TauriPlugin
@@ -108,8 +122,17 @@ class DownloadPlugin(activity: Activity) : Plugin(activity) {
       } catch (e: Exception) {
          return invoke.reject(e.message)
       }
+      val options = try {
+         CreateOptions(
+            allowMetered = args.options?.allowMetered
+               ?: throw IllegalArgumentException("Missing required argument: options.allowMetered"),
+         )
+      } catch (e: Exception) {
+         return invoke.reject(e.message)
+      }
+
       scope.launch {
-         val response = withContext(Dispatchers.IO) { downloadManager.create(path, url) }
+         val response = withContext(Dispatchers.IO) { downloadManager.create(path, url, options) }
          invoke.resolve(JSObject(json.encodeToString(response)))
       }
    }

--- a/crates/download-manager/src/models.rs
+++ b/crates/download-manager/src/models.rs
@@ -9,7 +9,6 @@ use std::fmt;
 #[serde(rename_all = "camelCase")]
 pub struct CreateOptions {
    /// Whether the download may start on metered or constrained connections.
-   #[serde(default = "default_allow_metered")]
    pub allow_metered: bool,
 }
 
@@ -21,10 +20,6 @@ impl Default for CreateOptions {
    }
 }
 
-const fn default_allow_metered() -> bool {
-   true
-}
-
 /// Persisted download record. Stored in `downloads.json`.
 ///
 /// Does not contain `progress` — that is a derived value only present in
@@ -34,11 +29,8 @@ const fn default_allow_metered() -> bool {
 pub(crate) struct DownloadRecord {
    pub url: String,
    pub path: String,
-   #[serde(default)]
    pub options: CreateOptions,
-   #[serde(default)]
    pub received_bytes: u64,
-   #[serde(default)]
    pub total_bytes: Option<u64>,
    pub status: DownloadStatus,
 }
@@ -251,7 +243,7 @@ mod tests {
 
    #[test]
    fn test_deserialize_with_byte_fields() {
-      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","receivedBytes":500,"totalBytes":1000,"status":"paused"}"#;
+      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","options":{"allowMetered":true},"receivedBytes":500,"totalBytes":1000,"status":"paused"}"#;
       let record: DownloadRecord = serde_json::from_str(json).unwrap();
       assert_eq!(record.received_bytes, 500);
       assert_eq!(record.total_bytes, Some(1000));
@@ -260,21 +252,39 @@ mod tests {
    }
 
    #[test]
-   fn test_deserialize_without_byte_fields() {
-      // Old format without receivedBytes/totalBytes defaults to 0/None
-      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","status":"idle"}"#;
+   fn test_deserialize_without_received_bytes_fails() {
+      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","options":{"allowMetered":true},"status":"idle"}"#;
+
+      assert!(serde_json::from_str::<DownloadRecord>(json).is_err());
+   }
+
+   #[test]
+   fn test_deserialize_omitted_total_bytes_is_none() {
+      // serde reads an absent Option as None on its own, so totalBytes stays
+      // optional on the wire whatever attributes it carries. Nothing writes a
+      // record without it: None serializes as an explicit null.
+      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","options":{"allowMetered":true},"receivedBytes":500,"status":"idle"}"#;
       let record: DownloadRecord = serde_json::from_str(json).unwrap();
-      assert_eq!(record.received_bytes, 0);
+
       assert_eq!(record.total_bytes, None);
-      assert!(record.options.allow_metered);
+      assert_eq!(record.received_bytes, 500);
+   }
+
+   #[test]
+   fn test_deserialize_without_options_fails() {
+      let json = r#"{"url":"http://example.com/f.mp4","path":"/tmp/f.mp4","status":"idle"}"#;
+
+      assert!(serde_json::from_str::<DownloadRecord>(json).is_err());
    }
 
    #[test]
    fn test_create_options_default_allows_metered_connections() {
       assert!(CreateOptions::default().allow_metered);
+   }
 
-      let options: CreateOptions = serde_json::from_str("{}").unwrap();
-      assert!(options.allow_metered);
+   #[test]
+   fn test_create_options_without_allow_metered_fails() {
+      assert!(serde_json::from_str::<CreateOptions>("{}").is_err());
    }
 
    #[test]

--- a/examples/tauri-app/src/App.vue
+++ b/examples/tauri-app/src/App.vue
@@ -22,6 +22,10 @@
             <input type="checkbox" v-model="autoCreate">
             Auto-create
          </label>
+         <label class="toggle-label">
+            <input type="checkbox" v-model="allowMetered">
+            Allow metered
+         </label>
       </form>
       <!-- Manage Downloads -->
       <div class="download-list">
@@ -39,11 +43,13 @@ import DownloadView from './DownloadView.vue';
 interface DownloadViewItem {
    download: DownloadWithAnyStatus;
    url?: string;
+   allowMetered?: boolean;
 }
 
 const downloadURL = ref(''),
       downloads = ref<DownloadViewItem[]>(),
-      autoCreate = ref(true);
+      autoCreate = ref(true),
+      allowMetered = ref(true);
 
 onMounted(async () => {
    const items = await list();
@@ -59,17 +65,22 @@ async function getDownload() {
       return;
    }
 
-   const path = await join(await appDataDir(), 'downloads', filename);
+   // Captured before the first await: the policy is fixed when the download is
+   // listed, not re-read whenever it is eventually created.
+   const allowMeteredForItem = allowMetered.value,
+         path = await join(await appDataDir(), 'downloads', filename);
 
    let download = await get(path);
 
    if (download.status === DownloadStatus.Pending && autoCreate.value) {
-      const { download: created } = await download.create(downloadURL.value);
+      const { download: created } = await download.create(downloadURL.value, {
+         allowMetered: allowMeteredForItem,
+      });
 
       download = created;
    }
 
-   downloads.value?.push({ download, url: downloadURL.value });
+   downloads.value?.push({ download, url: downloadURL.value, allowMetered: allowMeteredForItem });
    downloadURL.value = '';
 }
 

--- a/examples/tauri-app/src/DownloadView.vue
+++ b/examples/tauri-app/src/DownloadView.vue
@@ -17,6 +17,9 @@
       <div class="item-info">
          <p class="state-text">State: {{ currentDownload.status }}</p>
          <p class="byte-text">{{ byteCount }}</p>
+         <p class="metered-text" v-if="currentDownload.status !== DownloadStatus.Pending">
+            Metered: {{ currentDownload.options.allowMetered ? 'allowed' : 'blocked' }}
+         </p>
          <p class="progress-text">{{ Math.round(currentDownload.progress) }}%</p>
       </div>
    </div>
@@ -36,7 +39,7 @@ import {
 } from 'tauri-plugin-download';
 import { UnlistenFn } from '@tauri-apps/api/event';
 
-const props = defineProps<{ download: DownloadWithAnyStatus, url?: string }>(),
+const props = defineProps<{ download: DownloadWithAnyStatus, url?: string, allowMetered?: boolean }>(),
       currentDownload = ref<DownloadWithAnyStatus>(props.download),
       showActions = computed(() => { return hasAnyAction(currentDownload.value); }),
       canCreate = computed(() => { return hasAction(currentDownload.value, DownloadAction.Create); }),
@@ -150,7 +153,9 @@ async function doCreate(): Promise<void> {
       return;
    }
 
-   const result = await currentDownload.value.create(props.url);
+   const result = await currentDownload.value.create(props.url, {
+      allowMetered: props.allowMetered ?? true,
+   });
 
    currentDownload.value = result.download;
 

--- a/guest-js/types.ts
+++ b/guest-js/types.ts
@@ -90,11 +90,11 @@ export interface ListenOptions {
 export interface CreateOptions {
 
    /**
-    * Whether the download may start or resume on metered or constrained
-    * connections. Defaults to `true`.
+    * Whether the download may transfer on metered or constrained connections.
+    * Defaults to `true`; the resolved value is on `download.options.allowMetered`.
     *
-    * The resolved value is exposed through `download.options.allowMetered`.
-    * This option is currently enforced on desktop only.
+    * With no eligible network, desktop rejects `start()` and `resume()` while iOS
+    * and Android accept the call and hold the transfer. See the README.
     */
    allowMetered?: boolean;
 }

--- a/ios/DownloadManagerExample/DownloadManagerExample/DownloadsView.swift
+++ b/ios/DownloadManagerExample/DownloadManagerExample/DownloadsView.swift
@@ -10,6 +10,7 @@ struct PendingDownload: Identifiable {
    var id: String { path.path }
    let url: URL
    let path: URL
+   let options: CreateOptions
 }
 
 struct DownloadsView: View {
@@ -17,6 +18,7 @@ struct DownloadsView: View {
    @State private var downloads: [DownloadItem] = []
    @State private var downloadURL: String = ""
    @State private var autoCreate: Bool = true
+   @State private var allowMetered: Bool = true
    @State private var pendingDownloads: [PendingDownload] = []
 
    var body: some View {
@@ -47,6 +49,12 @@ struct DownloadsView: View {
             .padding(.horizontal)
             
             Toggle("Auto-create", isOn: $autoCreate)
+               .padding(.horizontal)
+
+            // Fixed on the download at creation. Turn this off and the transfer is
+            // confined to unmetered, unconstrained networks — toggling Low Data Mode
+            // on the current Wi-Fi network is the cheapest way to exercise it.
+            Toggle("Allow metered networks", isOn: $allowMetered)
                .padding(.horizontal)
 
             List {
@@ -81,14 +89,18 @@ struct DownloadsView: View {
       let filename = url.lastPathComponent
       let path = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(filename)
       
+      // Read before the suspension point: the policy is fixed when the download is
+      // listed, not re-read whenever the task resumes.
+      let options = CreateOptions(allowMetered: allowMetered)
+
       Task {
          let download = await manager.get(path: path)
          
          if download.status == .pending {
             if autoCreate {
-               _ = await manager.create(path: path, url: url)
+               _ = await manager.create(path: path, url: url, options: options)
             } else {
-               pendingDownloads.append(PendingDownload(url: url, path: path))
+               pendingDownloads.append(PendingDownload(url: url, path: path, options: options))
             }
          }
       }
@@ -112,7 +124,7 @@ struct PendingDownloadRowView: View {
          
          Button(action: {
             Task {
-               _ = await manager.create(path: pending.path, url: pending.url)
+               _ = await manager.create(path: pending.path, url: pending.url, options: pending.options)
                onCreated()
             }
          }) {
@@ -152,6 +164,9 @@ struct DownloadRowView: View {
          Text(byteCount)
             .font(.caption)
             .foregroundColor(.secondary)
+         Text(item.options.allowMetered ? "Metered: allowed" : "Metered: blocked")
+            .font(.caption)
+            .foregroundColor(item.options.allowMetered ? .secondary : .orange)
          
          switch item.status {
          case .idle:

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/CreateOptions.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/CreateOptions.swift
@@ -1,0 +1,25 @@
+//
+//  CreateOptions.swift
+//  DownloadManagerKit
+//
+
+import Foundation
+
+/// Options fixed when a download is created: calling `create` again for an
+/// existing path returns the stored record with its original options.
+///
+/// Mirrors the Rust `CreateOptions` in `crates/download-manager/src/models.rs`.
+public struct CreateOptions: Codable, Sendable, Equatable {
+   /// Whether the download may transfer on metered or constrained connections.
+   ///
+   /// When `false` the task's `URLRequest` refuses cellular, expensive, and
+   /// constrained (Low Data Mode) paths, so the background session holds it until
+   /// an eligible network appears rather than failing it.
+   public var allowMetered: Bool
+
+   /// The default is what `DownloadManager.create` applies when a caller states
+   /// no policy. Decoding has no such fallback.
+   public init(allowMetered: Bool = true) {
+      self.allowMetered = allowMetered
+   }
+}

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadItem.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadItem.swift
@@ -15,6 +15,7 @@ public struct DownloadItem: Identifiable, Encodable, Sendable {
    
    public let url: URL
    public let path: URL
+   public let options: CreateOptions
    public let receivedBytes: UInt64
    public let totalBytes: UInt64?
    public let progress: Double
@@ -23,6 +24,7 @@ public struct DownloadItem: Identifiable, Encodable, Sendable {
    init(
       url: URL,
       path: URL,
+      options: CreateOptions,
       receivedBytes: UInt64,
       totalBytes: UInt64?,
       progress: Double,
@@ -30,6 +32,7 @@ public struct DownloadItem: Identifiable, Encodable, Sendable {
    ) {
       self.url = url
       self.path = path
+      self.options = options
       self.receivedBytes = receivedBytes
       self.totalBytes = totalBytes
       self.progress = progress
@@ -37,7 +40,7 @@ public struct DownloadItem: Identifiable, Encodable, Sendable {
    }
    
    enum CodingKeys: String, CodingKey {
-      case url, path, receivedBytes, totalBytes, progress, status
+      case url, path, options, receivedBytes, totalBytes, progress, status
    }
    
    public func encode(to encoder: Encoder) throws {
@@ -45,6 +48,7 @@ public struct DownloadItem: Identifiable, Encodable, Sendable {
 
       try container.encode(url, forKey: .url)
       try container.encode(path, forKey: .path)
+      try container.encode(options, forKey: .options)
       try container.encode(receivedBytes, forKey: .receivedBytes)
       try container.encode(progress, forKey: .progress)
       try container.encode(status, forKey: .status)

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
@@ -100,19 +100,27 @@ public final class DownloadManager: NSObject {
    /**
     Creates a download operation.
 
+    Options are fixed on creation: an existing record is returned unchanged,
+    keeping its original options, as on desktop.
+
     - Parameters:
       - path: The download path.
       - url: The download URL for the resource.
+      - options: Network policy persisted with the download.
     - Returns: The download operation.
     */
-   public func create(path: URL, url: URL) async -> DownloadActionResponse {
+   public func create(
+      path: URL,
+      url: URL,
+      options: CreateOptions = CreateOptions()
+   ) async -> DownloadActionResponse {
       await ensureReconciled()
 
       if let existing = await store.findByPath(path) {
          return DownloadActionResponse(download: existing.toItem(), expectedStatus: .idle)
       }
 
-      let record = DownloadRecord(url: url, path: path)
+      let record = DownloadRecord(url: url, path: path, options: options)
       await store.append(record)
       let item = await emitChanged(record)
       
@@ -142,7 +150,7 @@ public final class DownloadManager: NSObject {
       record.setStatus(.inProgress)
       await store.update(record)
 
-      let task = session.downloadTask(with: record.url)
+      let task = session.downloadTask(with: Self.request(for: record))
       task.taskDescription = path.path
       task.resume()
       
@@ -180,6 +188,10 @@ public final class DownloadManager: NSObject {
       let task: URLSessionDownloadTask
 
       if let resumeData, !resumeData.isEmpty {
+         // The one task this manager creates without building the request: resume
+         // data carries the original NSURLRequest, so the policy set by request(for:)
+         // at start() survives. Confirmed on device, but Apple does not document
+         // resume data as preserving request properties — re-check on new iOS majors.
          task = session.downloadTask(withResumeData: resumeData)
       } else {
          os_log(.info, log: Log.downloadManager,
@@ -192,7 +204,7 @@ public final class DownloadManager: NSObject {
          record.setBytes(received: 0, total: record.totalBytes)
          await store.update(record)
 
-         task = session.downloadTask(with: record.url)
+         task = session.downloadTask(with: Self.request(for: record))
       }
 
       task.taskDescription = path.path
@@ -458,6 +470,32 @@ public final class DownloadManager: NSObject {
 
    private func ensureReconciled() async {
       await reconcileTask?.value
+   }
+
+   /// Builds the request a download's task runs on, applying the record's network
+   /// policy.
+   ///
+   /// The policy is per-request rather than per-session because one background
+   /// session is shared by every download. Its configuration stays permissive and
+   /// the effective policy is the intersection of the two, so restricting here is
+   /// what makes the option per-download.
+   ///
+   /// A restricted task is not rejected: a background session waits for a path
+   /// that satisfies the request and starts transferring once one appears.
+   /// Desktop, having no such scheduler, rejects `start()`/`resume()` instead.
+   static func request(for record: DownloadRecord) -> URLRequest {
+      var request = URLRequest(url: record.url)
+      let allowMetered = record.options.allowMetered
+
+      // allowsExpensiveNetworkAccess covers cellular and personal hotspots;
+      // allowsConstrainedNetworkAccess covers Low Data Mode. Together with
+      // allowsCellularAccess they match the desktop check, which rejects a
+      // connection reported as either metered or constrained.
+      request.allowsCellularAccess = allowMetered
+      request.allowsExpensiveNetworkAccess = allowMetered
+      request.allowsConstrainedNetworkAccess = allowMetered
+
+      return request
    }
 
    /// Decides what a record left `inProgress` with no task behind it should become.

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
@@ -525,22 +525,22 @@ public final class DownloadManager: NSObject {
    /// Reconciles the store against the session's live tasks.
    ///
    /// Background-session tasks outlive the process and are restored alongside the
-   /// session, so a record is reverted only when the session reports no task for
-   /// its path — otherwise a download that is genuinely still running would be
-   /// clobbered. Android's reconcileStoreOnInit() needs no such check, because
-   /// WorkManager reruns the worker and it rewrites the status itself.
+   /// session, so a record is reverted only when the session reports no task for its
+   /// path — otherwise a download still running would be clobbered. Android needs no
+   /// such check: its worker constructs the manager before transferring, so
+   /// reconciliation always precedes any transfer — though a backoff or the unmetered
+   /// constraint can leave a record reading Paused or Idle for a while first.
    ///
-   /// That live-task check is also why the delegate handlers — handleProgress,
-   /// handleFinished, handleError — do not await ensureReconciled(), and must not
-   /// start doing so: gating them would serialize every progress callback behind
-   /// reconciliation for no benefit. They are already safe against it because
+   /// That check is also why the delegate handlers — handleProgress, handleFinished,
+   /// handleError — do not await ensureReconciled(), and must not start: gating them
+   /// would serialize every progress callback behind reconciliation for no benefit.
+   /// They are already safe because
    ///
-   /// - this reverts only records with no live task, while a callback fires only
-   ///   for a task that exists, so the two act on disjoint records;
-   /// - a new task can only appear via start()/resume(), which do await the gate,
-   ///   so none can be created while this is running; and
+   /// - this reverts only records with no live task, while a callback fires only for
+   ///   a task that exists, so the two act on disjoint records;
+   /// - a new task can only appear via start()/resume(), which do await the gate; and
    /// - if a restored task finishes mid-reconcile and handleFinished removes its
-   ///   record, the batched update below cannot resurrect it — DownloadStore's
+   ///   record, the batched update cannot resurrect it — DownloadStore's
    ///   update(_ records:) writes only paths that still exist.
    private func reconcileStore() async {
       let livePaths = Set(await session.allTasks.compactMap { $0.taskDescription })

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadRecord.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadRecord.swift
@@ -16,6 +16,7 @@ struct DownloadRecord: Identifiable, Codable, Sendable {
 
    let url: URL
    let path: URL
+   let options: CreateOptions
    private(set) var receivedBytes: UInt64
    private(set) var totalBytes: UInt64?
    private(set) var status: DownloadStatus
@@ -24,6 +25,7 @@ struct DownloadRecord: Identifiable, Codable, Sendable {
    init(
       url: URL,
       path: URL,
+      options: CreateOptions = CreateOptions(),
       receivedBytes: UInt64 = 0,
       totalBytes: UInt64? = nil,
       status: DownloadStatus = .idle,
@@ -31,6 +33,7 @@ struct DownloadRecord: Identifiable, Codable, Sendable {
    ) {
       self.url = url
       self.path = path
+      self.options = options
       self.receivedBytes = receivedBytes
       self.totalBytes = totalBytes
       self.status = status
@@ -73,6 +76,7 @@ struct DownloadRecord: Identifiable, Codable, Sendable {
       return DownloadItem(
          url: url,
          path: path,
+         options: options,
          receivedBytes: receivedBytes,
          totalBytes: totalBytes,
          progress: progress,

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadManagerTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadManagerTests.swift
@@ -130,4 +130,35 @@ final class DownloadManagerTests: XCTestCase {
 
       return url
    }
+
+   // MARK: - Network policy
+
+   private func idleRecord(allowMetered: Bool) -> DownloadRecord {
+      return DownloadRecord(
+         url: URL(string: "http://example.com/file.mp4")!,
+         path: URL(fileURLWithPath: "/tmp/file.mp4"),
+         options: CreateOptions(allowMetered: allowMetered)
+      )
+   }
+
+   func testUnrestrictedRequestLeavesEveryPathAllowed() {
+      let request = DownloadManager.request(for: idleRecord(allowMetered: true))
+
+      XCTAssertEqual(request.url, URL(string: "http://example.com/file.mp4"))
+      XCTAssertTrue(request.allowsCellularAccess)
+      XCTAssertTrue(request.allowsExpensiveNetworkAccess)
+      XCTAssertTrue(request.allowsConstrainedNetworkAccess)
+   }
+
+   func testRestrictedRequestRefusesMeteredAndConstrainedPaths() {
+      // All three, not just allowsCellularAccess: expensive covers personal
+      // hotspots and constrained covers Low Data Mode, which together match the
+      // desktop check that rejects a metered *or* constrained connection.
+      let request = DownloadManager.request(for: idleRecord(allowMetered: false))
+
+      XCTAssertEqual(request.url, URL(string: "http://example.com/file.mp4"))
+      XCTAssertFalse(request.allowsCellularAccess)
+      XCTAssertFalse(request.allowsExpensiveNetworkAccess)
+      XCTAssertFalse(request.allowsConstrainedNetworkAccess)
+   }
 }

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadRecordTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadRecordTests.swift
@@ -150,7 +150,7 @@ final class DownloadRecordTests: XCTestCase {
 
       XCTAssertEqual(
          Set(json.keys),
-         ["url", "path", "receivedBytes", "totalBytes", "progress", "status"]
+         ["url", "path", "options", "receivedBytes", "totalBytes", "progress", "status"]
       )
    }
 
@@ -173,6 +173,7 @@ final class DownloadRecordTests: XCTestCase {
       // field names drifted on both sides together.
       let json = """
       {"url":"http://example.com/f.mp4","path":"file:///tmp/f.mp4",\
+      "options":{"allowMetered":true},\
       "receivedBytes":500,"totalBytes":1000,"status":"paused"}
       """
 
@@ -201,6 +202,85 @@ final class DownloadRecordTests: XCTestCase {
       XCTAssertEqual(decoded.status, .paused)
       // progress is derived via toItem(), not stored.
       XCTAssertEqual(decoded.toItem().progress, 50.0)
+   }
+
+
+   // MARK: - Network policy
+
+   func testUnstatedPolicyAllowsMeteredConnections() {
+      // The API default, applied when a caller states no policy. It is not a
+      // decoding fallback — a persisted record must spell the value out.
+      XCTAssertTrue(sampleRecord().options.allowMetered)
+      XCTAssertTrue(CreateOptions().allowMetered)
+   }
+
+   func testRecordWithoutOptionsFailsToDecode() {
+      // The policy is decided once, at creation. A record that has lost it cannot
+      // be read back as anything trustworthy, so decoding refuses rather than
+      // assuming the permissive default.
+      let json = """
+      {"url":"http://example.com/f.mp4","path":"file:///tmp/f.mp4",\
+      "receivedBytes":0,"totalBytes":null,"status":"idle"}
+      """
+
+      XCTAssertThrowsError(
+         try JSONDecoder().decode(DownloadRecord.self, from: Data(json.utf8))
+      )
+   }
+
+   func testRecordWithEmptyOptionsFailsToDecode() {
+      let json = """
+      {"url":"http://example.com/f.mp4","path":"file:///tmp/f.mp4","options":{},\
+      "receivedBytes":0,"totalBytes":null,"status":"idle"}
+      """
+
+      XCTAssertThrowsError(
+         try JSONDecoder().decode(DownloadRecord.self, from: Data(json.utf8))
+      )
+   }
+
+   func testRecordDecodesARestrictedPolicy() throws {
+      let json = """
+      {"url":"http://example.com/f.mp4","path":"file:///tmp/f.mp4",\
+      "options":{"allowMetered":false},\
+      "receivedBytes":0,"totalBytes":null,"status":"idle"}
+      """
+
+      let record = try JSONDecoder().decode(DownloadRecord.self, from: Data(json.utf8))
+
+      XCTAssertFalse(record.options.allowMetered)
+   }
+
+   func testRecordRoundTripsARestrictedPolicy() throws {
+      let record = DownloadRecord(
+         url: URL(string: "http://example.com/file.mp4")!,
+         path: URL(fileURLWithPath: "/tmp/file.mp4"),
+         options: CreateOptions(allowMetered: false)
+      )
+
+      let decoded = try JSONDecoder().decode(
+         DownloadRecord.self,
+         from: try JSONEncoder().encode(record)
+      )
+
+      XCTAssertFalse(decoded.options.allowMetered)
+   }
+
+   func testItemEncodesTheResolvedPolicy() throws {
+      let record = DownloadRecord(
+         url: URL(string: "http://example.com/file.mp4")!,
+         path: URL(fileURLWithPath: "/tmp/file.mp4"),
+         options: CreateOptions(allowMetered: false)
+      )
+
+      let json = try XCTUnwrap(
+         try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(record.toItem())
+         ) as? [String: Any]
+      )
+      let options = try XCTUnwrap(json["options"] as? [String: Any])
+
+      XCTAssertEqual(options["allowMetered"] as? Bool, false)
    }
 
    // MARK: - Action response

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadStoreTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadStoreTests.swift
@@ -40,7 +40,7 @@ final class DownloadStoreTests: XCTestCase {
 
    func testLoadsPersistedRecords() {
       write("""
-      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","receivedBytes":500,"totalBytes":1000,"status":"paused"}]
+      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":500,"totalBytes":1000,"status":"paused"}]
       """)
 
       let records = DownloadStore.load(from: savePath)
@@ -49,6 +49,7 @@ final class DownloadStoreTests: XCTestCase {
       XCTAssertEqual(records.first?.receivedBytes, 500)
       XCTAssertEqual(records.first?.totalBytes, 1000)
       XCTAssertEqual(records.first?.status, .paused)
+      XCTAssertEqual(records.first?.options.allowMetered, true)
    }
 
 
@@ -61,9 +62,9 @@ final class DownloadStoreTests: XCTestCase {
       // decoded in one call, so the middle element takes both good records with it.
       // Invert this test when per-record decoding lands (#64).
       write("""
-      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","receivedBytes":1,"status":"paused"},
+      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":1,"status":"paused"},
        {"url":"http://example.com/b.mp4","status":"paused"},
-       {"url":"http://example.com/c.mp4","path":"file:///tmp/c.mp4","receivedBytes":3,"status":"idle"}]
+       {"url":"http://example.com/c.mp4","path":"file:///tmp/c.mp4","options":{"allowMetered":true},"receivedBytes":3,"status":"idle"}]
       """)
 
       XCTAssertEqual(DownloadStore.load(from: savePath).count, 0)
@@ -77,7 +78,7 @@ final class DownloadStoreTests: XCTestCase {
 
    func testUnknownKeysAreIgnored() {
       write("""
-      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","receivedBytes":7,"status":"idle","somethingNew":42}]
+      [{"url":"http://example.com/a.mp4","path":"file:///tmp/a.mp4","options":{"allowMetered":true},"receivedBytes":7,"status":"idle","somethingNew":42}]
       """)
 
       XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 7)

--- a/ios/Sources/DownloadPlugin.swift
+++ b/ios/Sources/DownloadPlugin.swift
@@ -10,6 +10,7 @@ class PathArgs: Decodable {
 class CreateArgs: Decodable {
    let path: String
    let url: String
+   let options: CreateOptions
 }
 
 class DownloadPlugin: Plugin {
@@ -49,7 +50,11 @@ class DownloadPlugin: Plugin {
       let path = try parsePath(args.path)
       let url = try parseURL(args.url)
       Task {
-         let response = await self.downloadManager.create(path: path, url: url)
+         let response = await self.downloadManager.create(
+            path: path,
+            url: url,
+            options: args.options
+         )
          invoke.resolve(response)
       }
    }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -28,8 +28,8 @@ pub(crate) async fn create<R: Runtime>(
    }
    #[cfg(mobile)]
    {
-      let _ = options;
-      app.download().create(&path, &url)
+      app.download()
+         .create(&path, &url, options.unwrap_or_default())
    }
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -19,17 +19,17 @@ pub(crate) async fn create<R: Runtime>(
    app: AppHandle<R>,
    path: String,
    url: String,
-   options: Option<CreateOptions>,
+   options: Option<CreateOptionsArgs>,
 ) -> Result<DownloadActionResponse> {
+   let options = options.map(CreateOptions::from).unwrap_or_default();
+
    #[cfg(desktop)]
    {
-      app.download()
-         .create_with_options(&path, &url, options.unwrap_or_default())
+      app.download().create_with_options(&path, &url, options)
    }
    #[cfg(mobile)]
    {
-      app.download()
-         .create(&path, &url, options.unwrap_or_default())
+      app.download().create(&path, &url, options)
    }
 }
 

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -90,10 +90,16 @@ impl<R: Runtime> Download<R> {
    /// # Arguments
    /// - `path` - The download path.
    /// - `url` - The download URL for the resource.
+   /// - `options` - Network policy persisted with the download.
    ///
    /// # Returns
    /// The download operation.
-   pub fn create(&self, path: &str, url: &str) -> crate::Result<DownloadActionResponse> {
+   pub fn create(
+      &self,
+      path: &str,
+      url: &str,
+      options: CreateOptions,
+   ) -> crate::Result<DownloadActionResponse> {
       self
          .0
          .run_mobile_plugin(
@@ -101,6 +107,7 @@ impl<R: Runtime> Download<R> {
             CreateArgs {
                path: path.to_string(),
                url: url.to_string(),
+               options,
             },
          )
          .map_err(Into::into)

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,6 +2,24 @@
 #[cfg(desktop)]
 pub use download_manager::{CreateOptions, DownloadActionResponse, DownloadItem};
 
+/// Wire form of [`CreateOptions`] for the `create` command. TypeScript declares
+/// `allowMetered` optional, so `create(url, {})` must mean "unstated" rather than
+/// fail; holding that tolerance here lets the persisted [`CreateOptions`] require
+/// the value. Unknown keys are ignored, not rejected.
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateOptionsArgs {
+   pub allow_metered: Option<bool>,
+}
+
+impl From<CreateOptionsArgs> for CreateOptions {
+   fn from(arg: CreateOptionsArgs) -> Self {
+      Self {
+         allow_metered: arg.allow_metered.unwrap_or(Self::default().allow_metered),
+      }
+   }
+}
+
 // Mobile model types (iOS, Android)
 #[cfg(mobile)]
 mod mobile_types {
@@ -31,13 +49,9 @@ mod mobile_types {
    pub struct DownloadItem {
       pub url: String,
       pub path: String,
-      #[serde(default)]
       pub options: CreateOptions,
-      #[serde(default)]
       pub received_bytes: u64,
-      #[serde(default)]
       pub total_bytes: Option<u64>,
-      #[serde(default)]
       pub progress: f64,
       pub status: DownloadStatus,
    }
@@ -86,3 +100,87 @@ mod mobile_types {
 
 #[cfg(mobile)]
 pub use mobile_types::{CreateArgs, CreateOptions, DownloadActionResponse, DownloadItem, PathArgs};
+
+#[cfg(test)]
+mod tests {
+   use super::*;
+
+   #[test]
+   fn test_unstated_policy_takes_the_api_default() {
+      // `create(url, {})` from TypeScript decodes to this: serde reads an absent
+      // Option as None, so the default is resolved here rather than by tolerating
+      // a missing field on the persisted `CreateOptions`.
+      let arg = CreateOptionsArgs {
+         allow_metered: None,
+      };
+
+      assert_eq!(
+         CreateOptions::from(arg).allow_metered,
+         CreateOptions::default().allow_metered
+      );
+   }
+
+   #[test]
+   fn test_stated_policy_is_carried_through() {
+      let arg = CreateOptionsArgs {
+         allow_metered: Some(false),
+      };
+
+      assert!(!CreateOptions::from(arg).allow_metered);
+   }
+
+   #[test]
+   fn test_empty_json_object_resolves_to_the_api_default() {
+      // The `create(url, {})` case the struct's doc comment describes, decoded
+      // through serde rather than constructed, so it holds at the wire.
+      let arg: CreateOptionsArgs = serde_json::from_str("{}").unwrap();
+
+      assert_eq!(arg.allow_metered, None);
+      assert_eq!(
+         CreateOptions::from(arg).allow_metered,
+         CreateOptions::default().allow_metered
+      );
+   }
+
+   #[test]
+   fn test_json_false_is_carried_through_to_the_resolved_options() {
+      let arg: CreateOptionsArgs = serde_json::from_str(r#"{"allowMetered":false}"#).unwrap();
+
+      assert_eq!(arg.allow_metered, Some(false));
+      assert!(!CreateOptions::from(arg).allow_metered);
+   }
+
+   #[test]
+   fn test_json_true_is_carried_through_to_the_resolved_options() {
+      let arg: CreateOptionsArgs = serde_json::from_str(r#"{"allowMetered":true}"#).unwrap();
+
+      assert_eq!(arg.allow_metered, Some(true));
+      assert!(CreateOptions::from(arg).allow_metered);
+   }
+
+   #[test]
+   fn test_json_null_is_treated_the_same_as_the_field_being_absent() {
+      // Null and absent are deliberately the same under "unstated" semantics.
+      let arg: CreateOptionsArgs = serde_json::from_str(r#"{"allowMetered":null}"#).unwrap();
+
+      assert_eq!(arg.allow_metered, None);
+      assert_eq!(
+         CreateOptions::from(arg).allow_metered,
+         CreateOptions::default().allow_metered
+      );
+   }
+
+   #[test]
+   fn test_unrecognised_key_is_ignored_and_resolves_to_the_default() {
+      // Characterisation test, not a design goal: `guest-js/actions.ts` forwards
+      // the caller's options object verbatim, so `deny_unknown_fields` would break
+      // a caller whose variable is typed wider than the options shape.
+      let arg: CreateOptionsArgs = serde_json::from_str(r#"{"allowmetered":false}"#).unwrap();
+
+      assert_eq!(arg.allow_metered, None);
+      assert_eq!(
+         CreateOptions::from(arg).allow_metered,
+         CreateOptions::default().allow_metered
+      );
+   }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,25 +7,10 @@ pub use download_manager::{CreateOptions, DownloadActionResponse, DownloadItem};
 mod mobile_types {
    use serde::{Deserialize, Serialize};
 
-   /// Options fixed when a download is created.
-   #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-   #[serde(rename_all = "camelCase")]
-   pub struct CreateOptions {
-      #[serde(default = "default_allow_metered")]
-      pub allow_metered: bool,
-   }
-
-   impl Default for CreateOptions {
-      fn default() -> Self {
-         Self {
-            allow_metered: true,
-         }
-      }
-   }
-
-   const fn default_allow_metered() -> bool {
-      true
-   }
+   /// Shared with desktop rather than mirrored. The type sits on the bridge in both
+   /// directions now, and a second definition of it — with its own copy of the
+   /// default — could drift without the compiler, the tests, or CI noticing.
+   pub use download_manager::CreateOptions;
 
    #[derive(Serialize)]
    #[serde(rename_all = "camelCase")]
@@ -38,6 +23,7 @@ mod mobile_types {
    pub struct CreateArgs {
       pub path: String,
       pub url: String,
+      pub options: CreateOptions,
    }
 
    #[derive(Debug, Clone, Default, Deserialize, Serialize)]


### PR DESCRIPTION
Closes #13.

#59 added `allowMetered` for desktop, where `start()` and `resume()` reject on a metered or constrained connection. This ports it to mobile by handing the constraint to each OS scheduler rather than reimplementing the desktop probe:

* **iOS** sets `allowsCellularAccess`, `allowsExpensiveNetworkAccess` and `allowsConstrainedNetworkAccess` on the task's `URLRequest`. The policy is per-request because one background `URLSession` is shared by every download.
* **Android** sets `NetworkType.UNMETERED` on the WorkManager request, replacing the `NetworkType.CONNECTED` it already built.

Desktop refuses where mobile waits, and the README carries the full per-platform table. Both mobile platforms hold a restricted download and continue on their own once an eligible network appears.

### Also in here

* Decode is strict on all three platforms: a persisted record states its policy or fails, rather than reading back as permissive. The API default moved to `CreateOptionsArgs`, the command's wire form, since the TypeScript API declares `allowMetered` optional.
* All three example apps expose the option and show each download's resolved policy.
* `handleTransientError` now retries with an attempt cap instead of failing terminally. Without this a network change mid-transfer left an Android download `Paused` forever; the cap keeps a download that fails for its own reasons from retrying invisibly.

### Verified on device

Tested on an iPhone (Low Data Mode) and a Galaxy S20 FE (Wi-Fi marked metered):

* A restricted download holds at zero bytes and begins once the network qualifies.
* Marking the network metered mid-transfer stalls it, and it continues by itself.
* On iOS the policy survives pause and resume through `downloadTask(withResumeData:)`, which takes no request and inherits it — the one path that could have failed silently.

The README documents how to run these checks under each platform's Support section.

### Notes for review

* `handleTransientError` is pre-existing code this branch changes. It catches every transient failure, not just the network-policy stall, so the behaviour change reaches ordinary downloads too — hence the attempt cap rather than an unbounded retry.
* Nothing in CI compiles anything under `#[cfg(mobile)]`: `cargo check --workspace --all-targets` runs on Linux and `--all-targets` means target kinds, not triples. This branch adds a required field and a signature change in there. Worth a follow-up adding `cargo check --target aarch64-apple-ios` to the workflow.
