### PR TITLE
fix: write the download store atomically

### DIFF
--- a/crates/download-manager/Cargo.toml
+++ b/crates/download-manager/Cargo.toml
@@ -11,6 +11,7 @@ connectivity = { version = "0.1.0", git = "https://github.com/silvermine/tauri-p
 futures = "0.3.31"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+tempfile = "3.26.0"
 thiserror = "2.0.17"
 tokio = "1.49.0"
 tracing = { version = "0.1.41", default-features = false, features = ["std", "log", "release_max_level_off"] }
@@ -20,6 +21,5 @@ reqwest-retry = "0.9.0"
 url = "2.5.8"
 
 [dev-dependencies]
-tempfile = "3.26.0"
 tokio = { version = "1.49.0", features = ["rt", "macros", "time"] }
 wiremock = "0.6.2"

--- a/crates/download-manager/src/store.rs
+++ b/crates/download-manager/src/store.rs
@@ -1,6 +1,9 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::io::Write;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+
+use tempfile::NamedTempFile;
 
 use crate::Error;
 use crate::models::{DownloadRecord, DownloadStatus};
@@ -154,18 +157,51 @@ impl DownloadStore {
 /// Accepts `&StoreInner` directly rather than `&self` because callers already hold the
 /// `MutexGuard` when they call this. Taking `&self` would attempt to re-acquire the lock
 /// on the same thread, causing a deadlock since `Mutex` is not re-entrant.
+///
+/// Writes atomically, as iOS and Android do, so a crash mid-write leaves the previous store
+/// intact rather than truncated JSON. Two consequences: the store takes the temp file's
+/// `0600` on Unix, leaving it app-private as it is on mobile, and the directory is not
+/// fsynced, so a power loss can cost the last update but never the file.
 fn save_inner(inner: &StoreInner) -> crate::Result<()> {
-   if let Some(parent) = Path::new(&inner.path).parent()
-      && !parent.exists()
-   {
-      fs::create_dir_all(parent)
-         .map_err(|e| Error::Store(format!("Failed to create store directory: {}", e)))?;
-   }
+   let parent = inner
+      .path
+      .parent()
+      .ok_or_else(|| Error::Store("Store path has no parent directory".to_string()))?;
 
+   fs::create_dir_all(parent)
+      .map_err(|e| Error::Store(format!("Failed to create store directory: {}", e)))?;
+
+   // Serialize before touching the disk so a failure here cannot leave a temp file behind.
    let data = serde_json::to_vec(&inner.downloads)
       .map_err(|e| Error::Store(format!("Failed to serialize store: {}", e)))?;
-   fs::write(&inner.path, &data)
+
+   // The temp file has to be a sibling of the store: `rename` cannot cross a mount point.
+   // `NamedTempFile` removes itself on drop, so the early returns below leave no debris.
+   let mut temp = NamedTempFile::new_in(parent)
+      .map_err(|e| Error::Store(format!("Failed to create temp store file: {}", e)))?;
+
+   temp
+      .write_all(&data)
       .map_err(|e| Error::Store(format!("Failed to write store: {}", e)))?;
+
+   // Sync before the rename, as Android's `AtomicFile.finishWrite` does. `flush` would be
+   // a no-op — the writes are unbuffered — and the rename only publishes a directory entry,
+   // so without this a crash can leave a correctly named file whose contents never landed.
+   temp.as_file().sync_all().map_err(|e| {
+      Error::Store(format!(
+         "Failed to sync store to disk: {} at path {:?}",
+         e,
+         temp.path()
+      ))
+   })?;
+
+   temp.persist(&inner.path).map_err(|e| {
+      Error::Store(format!(
+         "Failed to replace store: {} at path {:?}",
+         e.error, inner.path
+      ))
+   })?;
+
    Ok(())
 }
 
@@ -433,5 +469,56 @@ mod tests {
       let store = DownloadStore::new(dir.path().join("nested/dir/downloads.json"));
       store.create(sample_record("/tmp/file.mp4")).unwrap();
       assert!(dir.path().join("nested/dir/downloads.json").exists());
+   }
+
+   /// The temp file is removed on drop, so an early return between creating it and
+   /// renaming it into place leaves no debris. A directory at the destination makes the
+   /// rename fail, which is the only publish error reachable without fault injection.
+   #[test]
+   fn test_failed_save_leaves_no_temp_files() {
+      let dir = TempDir::new().unwrap();
+      let path = dir.path().join("downloads.json");
+      fs::create_dir(&path).unwrap();
+      let store = DownloadStore::new(path);
+
+      assert!(store.create(sample_record("/tmp/file.mp4")).is_err());
+
+      let entries: Vec<_> = fs::read_dir(dir.path())
+         .unwrap()
+         .map(|entry| entry.unwrap().file_name())
+         .collect();
+      assert_eq!(entries, vec!["downloads.json"]);
+   }
+
+   #[test]
+   fn test_save_leaves_no_temp_files() {
+      let (store, dir) = temp_store();
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
+      store.delete("/tmp/file.mp4").unwrap();
+
+      let entries: Vec<_> = fs::read_dir(dir.path())
+         .unwrap()
+         .map(|entry| entry.unwrap().file_name())
+         .collect();
+      assert_eq!(entries, vec!["downloads.json"]);
+   }
+
+   /// The store is published by renaming a temp file over it, so each save replaces the
+   /// file rather than rewriting it. An in-place write would keep the same inode.
+   #[cfg(unix)]
+   #[test]
+   fn test_save_replaces_rather_than_rewriting_in_place() {
+      use std::os::unix::fs::MetadataExt;
+
+      let (store, dir) = temp_store();
+      let path = dir.path().join("downloads.json");
+
+      store.create(sample_record("/tmp/file.mp4")).unwrap();
+      let first = fs::metadata(&path).unwrap().ino();
+
+      store.create(sample_record("/tmp/other.mp4")).unwrap();
+      let second = fs::metadata(&path).unwrap().ino();
+
+      assert_ne!(first, second);
    }
 }


### PR DESCRIPTION
Refs #64.

`downloads.json` was the one store write that could tear. iOS writes it with `Data.write(options: .atomic)` and Android through `AtomicFile`; Rust called `fs::write` straight over the live file, so a crash or power loss mid-write could leave truncated JSON behind. That file then fails to parse on the next launch, `DownloadManager::new` warns and carries on with an empty store, and the first `create`/`update`/`delete` writes `[]` over whatever survived.

`save_inner` now serializes to a buffer, writes a sibling `NamedTempFile`, fsyncs it, and renames it over the store. `tempfile` moves from dev-dependencies to dependencies, supplying the two things std does not: a unique name in the target directory, and removal on drop so no early return leaks a temp file.

### Two consequences, both deliberate

* **The store becomes `0600` on Unix**, not `0644` — `rename` replaces the inode, so the temp file's mode wins. That matches mobile, where the store is app-private by sandbox, and it is a real tightening: the file holds download URLs, which routinely carry presigned tokens and API keys.
* **The parent directory is not fsynced.** If the rename itself is not durable the previous, valid store survives — a lost update, never a corrupt file, which is the whole property being bought. Neither `.atomic` nor `AtomicFile` fsyncs the directory either.

### Tests

Two, and I checked both discriminate rather than assuming they do:

* `test_save_replaces_rather_than_rewriting_in_place` compares the inode across two saves. Against the old `fs::write` it fails, because an in-place write reuses the inode.
* `test_failed_save_leaves_no_temp_files` puts a directory at the destination so the publishing rename fails with `EISDIR`, then asserts nothing is left behind. Breaking the drop-based cleanup makes it fail with a stray `.tmpXXXXXX`.

`test_save_leaves_no_temp_files` covers the success path and passes against the old implementation too. It is a forward guard, not coverage of this change.

### Notes for review

* This closes the **truncated or corrupt file** cause in #64 and nothing else. A decode failure from any other cause still ends with the store overwritten by `[]`. #64 carries a proposal for the remaining work.
* `downloader.rs` is untouched. Adding `sync_all` to the payload rename would put desktop ahead of mobile rather than level with it — Android's `DownloadWorker` never calls `fd.sync()` and iOS delegates to `FileManager.moveItem` — and it would fsync a possibly multi-gigabyte file at the moment the download completes.
* The `#[cfg(windows)]` pre-delete in `downloader.rs` is left alone, but its comment is wrong: `fs::rename` does replace an existing destination on Windows (`MoveFileExW` or `SetFileInformationByHandle`). Removing the pre-delete wants a Windows runner, which CI does not have.
* On macOS `sync_all` is `fcntl(F_FULLFSYNC)`, a full drive-cache flush — measured here at ~6ms per save against ~244µs for the old `fs::write`. The store persists only on create/start/pause/cancel/complete, since the progress path uses `update_no_persist`, so that is 4–6 saves per download. `init()` is the one place it compounds: it reverts each interrupted record with its own save, so K interrupted downloads cost K flushes on the event-loop thread at startup. Worth batching, separately.