### PR TITLE
feat: support setting an HTTP user agent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ tauri-plugin = { version = "2.5.1", features = ["build"] }
 
 [dev-dependencies]
 serde_json = "1.0.145"
+tauri = { version = "2.9.3", features = ["test"] }

--- a/README.md
+++ b/README.md
@@ -115,6 +115,58 @@ fn main() {
 }
 ```
 
+### Configuration
+
+Use `Builder` instead of `init()` to configure the plugin. `init()` is shorthand for
+`Builder::new().build()`.
+
+```rust
+fn main() {
+   tauri::Builder::default()
+      .plugin(
+         tauri_plugin_download::Builder::new()
+            .user_agent("my-app/1.0")
+            .build(),
+      )
+      .run(tauri::generate_context!())
+      .expect("error while running tauri application");
+}
+```
+
+| Method | Type | Default | Description |
+| --- | --- | --- | --- |
+| `user_agent` | `impl Into<String>` | None | `User-Agent` sent with every download request |
+
+#### User agent
+
+The setting is opt-in. Leaving it unset keeps whatever each platform's own HTTP stack
+sends, which is not the same on all three:
+
+| Platform | Transport | User agent when unset |
+| --- | --- | --- |
+| Desktop | `reqwest` | none |
+| Android | OkHttp | `okhttp/<version>` |
+| iOS | `URLSession` | `<app>/<version> CFNetwork/… Darwin/…` |
+
+Setting it makes all three send the same value. It must be printable ASCII or a
+horizontal tab — Android's HTTP client rejects anything above `~`, so that is the rule
+all three share. An invalid value fails plugin initialization rather than surfacing
+later as a failed download on one platform. An empty value is accepted — it is legal
+HTTP, and sends an empty header rather than none.
+
+A download that outlives the process picks up a changed user agent differently on each
+platform:
+
+   * **Desktop** builds one HTTP client per process, so a download resumed after a
+     relaunch uses the new run's value.
+   * **Android** reads the current value whenever a download is enqueued, an explicit
+     `resume` included, so it behaves like desktop. Only when WorkManager re-runs a
+     stranded worker itself — in a process where the plugin never loaded — does it fall
+     back to the value captured in the work request.
+   * **iOS** keeps the value a download started with when it resumes from resume data,
+     which carries the original request. Without resume data — from a server with no
+     byte-range support, say — it restarts from zero and picks up the current value.
+
 ### API
 
 #### List downloads

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
@@ -3,6 +3,7 @@ package org.silvermine.downloadmanager
 import android.content.Context
 import android.util.Log
 import androidx.work.Constraints
+import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
@@ -23,6 +24,16 @@ import java.io.File
 class DownloadManager private constructor(context: Context) {
    internal val store = DownloadStore(context)
    private val workManager = WorkManager.getInstance(context)
+
+   /**
+    * The user agent sent with every download request, or `null` to leave OkHttp's
+    * own default in place.
+    *
+    * Set by the Tauri plugin during setup. Volatile because it is written on the
+    * main thread and read when a download is enqueued.
+    */
+   @Volatile
+   var userAgent: String? = null
 
    private val _changed = MutableSharedFlow<DownloadItem>(
       extraBufferCapacity = 64,
@@ -243,12 +254,7 @@ class DownloadManager private constructor(context: Context) {
    private fun enqueueDownload(record: DownloadRecord) {
       val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
          .setConstraints(constraintsFor(record.options))
-         .setInputData(
-            workDataOf(
-               DownloadWorker.KEY_URL to record.url,
-               DownloadWorker.KEY_PATH to record.path,
-            )
-         )
+         .setInputData(inputDataFor(record, userAgent))
          .addTag(WORK_TAG)
          .build()
 
@@ -262,6 +268,22 @@ class DownloadManager private constructor(context: Context) {
    private fun workName(path: String): String = "$WORK_TAG:$path"
 
    companion object {
+      /**
+       * Builds the work request's input data.
+       *
+       * The user agent is captured here rather than read by the worker: WorkManager
+       * can re-run a stranded worker in a fresh process with no Tauri activity, where
+       * the plugin never loads and [userAgent] is null. Only input data survives.
+       *
+       * Built here for the same reason as [constraintsFor].
+       */
+      internal fun inputDataFor(record: DownloadRecord, userAgent: String?): Data =
+         workDataOf(
+            DownloadWorker.KEY_URL to record.url,
+            DownloadWorker.KEY_PATH to record.path,
+            DownloadWorker.KEY_USER_AGENT to userAgent,
+         )
+
       /**
        * Builds the work request's constraints from a download's network policy.
        *

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
@@ -60,13 +60,11 @@ internal class DownloadWorker(
          // Check the size of the already downloaded part, if any.
          var downloadedSize = if (tempFile.exists()) tempFile.length() else 0L
 
-         // Build request with Range header for resuming.
-         val requestBuilder = Request.Builder().url(url)
-         if (downloadedSize > 0) {
-            requestBuilder.header("Range", "bytes=$downloadedSize-")
-         }
-
-         val response = executeWithRetry(requestBuilder.build())
+         // The user agent comes from the input data rather than the manager: a worker
+         // re-run after process death has no loaded plugin to have set it.
+         val response = executeWithRetry(
+            requestFor(url, inputData.getString(KEY_USER_AGENT), downloadedSize)
+         )
 
          response.use {
             // If we requested a Range but the server doesn't support partial downloads,
@@ -398,6 +396,28 @@ internal class DownloadWorker(
    companion object {
       const val KEY_URL = "download_url"
       const val KEY_PATH = "download_path"
+      const val KEY_USER_AGENT = "download_user_agent"
+
+      /**
+       * Builds the download request.
+       *
+       * A null [userAgent] leaves OkHttp's own default in place; a [downloadedSize]
+       * above zero asks the server to resume from there. Both headers are set here, so
+       * neither can displace the other.
+       *
+       * Built here rather than inline in [doWork], which needs [WorkerParameters] and
+       * so cannot be reached without WorkManager's test artifact.
+       */
+      internal fun requestFor(url: String, userAgent: String?, downloadedSize: Long): Request {
+         val builder = Request.Builder().url(url)
+
+         userAgent?.let { builder.header("User-Agent", it) }
+         if (downloadedSize > 0) {
+            builder.header("Range", "bytes=$downloadedSize-")
+         }
+
+         return builder.build()
+      }
 
       internal const val TAG = "DownloadWorker"
       internal const val DOWNLOAD_SUFFIX = ".download"

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
@@ -82,4 +82,26 @@ class DownloadManagerTest {
          DownloadManager.constraintsFor(CreateOptions(allowMetered = false)).requiredNetworkType,
       )
    }
+
+   // -- Work request input data --
+
+   @Test
+   fun `a configured user agent is captured in the work request`() {
+      val data = DownloadManager.inputDataFor(inProgressRecord(), userAgent = "my-app/1.0")
+
+      assertEquals("my-app/1.0", data.getString(DownloadWorker.KEY_USER_AGENT))
+      assertEquals("http://example.com/file.mp4", data.getString(DownloadWorker.KEY_URL))
+      assertEquals("/tmp/file.mp4", data.getString(DownloadWorker.KEY_PATH))
+   }
+
+   @Test
+   fun `no user agent stores a null value`() {
+      // The key is present with a null value, not absent: measured on work-runtime
+      // 2.9.1, `workDataOf(k to null)` gives size()==3 and containsKey()==true. Either
+      // way `getString` returns null, which the worker treats as "send no User-Agent",
+      // leaving OkHttp's default.
+      val data = DownloadManager.inputDataFor(inProgressRecord(), userAgent = null)
+
+      assertNull(data.getString(DownloadWorker.KEY_USER_AGENT))
+   }
 }

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadWorkerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadWorkerTest.kt
@@ -1,6 +1,8 @@
 package org.silvermine.downloadmanager
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -27,5 +29,41 @@ class DownloadWorkerTest {
       // increments the count without ever consulting the cap.
       assertTrue(DownloadWorker.isOutOfAttempts(5))
       assertTrue(DownloadWorker.isOutOfAttempts(6))
+   }
+
+   // -- Request construction --
+
+   @Test
+   fun `a configured user agent is set on the request`() {
+      val request = DownloadWorker.requestFor("https://example.com/f.bin", "my-app/1.0", 0L)
+
+      assertEquals("my-app/1.0", request.header("User-Agent"))
+   }
+
+   @Test
+   fun `no user agent leaves the header unset`() {
+      // Absent rather than empty: OkHttp then sends its own default.
+      val request = DownloadWorker.requestFor("https://example.com/f.bin", null, 0L)
+
+      assertNull(request.header("User-Agent"))
+   }
+
+   @Test
+   fun `a fresh download sends no range header`() {
+      // The common path, and the boundary of the resume condition: without this,
+      // widening `downloadedSize > 0` to `>= 0` changes no test outcome.
+      val request = DownloadWorker.requestFor("https://example.com/f.bin", "my-app/1.0", 0L)
+
+      assertNull(request.header("Range"))
+   }
+
+   @Test
+   fun `the user agent and range headers coexist on a resume`() {
+      // Mirrors the Rust test_user_agent_and_range_header_are_both_sent_on_resume:
+      // neither header may displace the other.
+      val request = DownloadWorker.requestFor("https://example.com/f.bin", "my-app/1.0", 4L)
+
+      assertEquals("my-app/1.0", request.header("User-Agent"))
+      assertEquals("bytes=4-", request.header("Range"))
    }
 }

--- a/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
+++ b/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
@@ -41,6 +41,17 @@ class CreateOptionsArgs {
    var allowMetered: Boolean? = null
 }
 
+/**
+ * Settings pushed by the Rust plugin at startup.
+ *
+ * Named for the payload rather than the setting so a second builder option is a new
+ * field here, not a second command.
+ */
+@InvokeArg
+class ConfigArgs {
+   var userAgent: String? = null
+}
+
 @InvokeArg
 class CreateArgs {
    var path: String? = null
@@ -74,6 +85,23 @@ class DownloadPlugin(activity: Activity) : Plugin(activity) {
    override fun onDestroy() {
       super.onDestroy()
       scope.cancel()
+   }
+
+   /**
+    * Applies the settings from the Rust plugin's builder.
+    *
+    * Invoked by the Rust plugin during setup rather than from the webview: Tauri
+    * fills the config it hands to [load] from `tauri.conf.json`, so a value set on
+    * the Rust builder can only arrive as a command.
+    */
+   @Command
+   fun configure(invoke: Invoke) {
+      val args = invoke.parseArgs(ConfigArgs::class.java)
+      val userAgent = args.userAgent
+         ?: return invoke.reject("Missing required argument: userAgent")
+
+      downloadManager.userAgent = userAgent
+      invoke.resolve()
    }
 
    @Command

--- a/crates/download-manager/src/downloader.rs
+++ b/crates/download-manager/src/downloader.rs
@@ -251,7 +251,7 @@ impl ProgressTracker {
 #[cfg(test)]
 mod tests {
    use super::*;
-   use crate::manager::{DownloadManager, OnChanged};
+   use crate::manager::{DownloadManager, DownloadManagerConfig, OnChanged};
    use crate::store::DownloadStore;
    use std::sync::{Arc, Mutex};
    use tempfile::TempDir;
@@ -267,13 +267,17 @@ mod tests {
    }
 
    fn make_fixture() -> TestFixture {
+      make_fixture_with_config(DownloadManagerConfig::default())
+   }
+
+   fn make_fixture_with_config(config: DownloadManagerConfig) -> TestFixture {
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
       let captured = events.clone();
       let on_changed: OnChanged = Arc::new(move |event| {
          captured.lock().unwrap().push(event);
       });
-      let manager = DownloadManager::new(dir.path().to_path_buf(), on_changed);
+      let manager = DownloadManager::new(dir.path().to_path_buf(), on_changed, config);
       TestFixture {
          manager,
          events,
@@ -608,7 +612,11 @@ mod tests {
          }
       });
 
-      let manager = DownloadManager::new(dir.path().to_path_buf(), on_changed);
+      let manager = DownloadManager::new(
+         dir.path().to_path_buf(),
+         on_changed,
+         DownloadManagerConfig::default(),
+      );
       *store_cell.lock().unwrap() = Some(manager.store.clone());
 
       let server = MockServer::start().await;
@@ -700,5 +708,119 @@ mod tests {
          events_with_status(&fixture.events, DownloadStatus::Completed),
          0
       );
+   }
+
+   /// Returns the `User-Agent` the mock server actually received, if any.
+   ///
+   /// Asserted on the request the server saw rather than on the client, because the
+   /// point of the setting is what reaches the far end of the wire.
+   async fn received_user_agent(server: &MockServer) -> Option<String> {
+      let requests = server.received_requests().await.unwrap();
+      assert_eq!(requests.len(), 1);
+      requests[0]
+         .headers
+         .get("user-agent")
+         .map(|value| value.to_str().unwrap().to_string())
+   }
+
+   #[tokio::test]
+   async fn test_configured_user_agent_is_sent_with_the_request() {
+      let fixture = make_fixture_with_config(DownloadManagerConfig {
+         user_agent: Some("my-app/1.0".to_string()),
+      });
+      let server = MockServer::start().await;
+
+      Mock::given(method("GET"))
+         .and(wm_path("/file"))
+         .respond_with(ResponseTemplate::new(200).set_body_bytes(b"body".to_vec()))
+         .mount(&server)
+         .await;
+
+      let dest = dest_path(&fixture, "file.bin");
+      let url = format!("{}/file", server.uri());
+      let item = seed_in_progress(&fixture.manager, &dest, &url);
+
+      download(&fixture.manager, item).await.unwrap();
+
+      assert_eq!(
+         received_user_agent(&server).await,
+         Some("my-app/1.0".to_string())
+      );
+   }
+
+   #[tokio::test]
+   async fn test_no_user_agent_is_sent_when_none_is_configured() {
+      // The setting is opt-in: leaving it unset must not start sending a header
+      // that consumers were not sending before.
+      let fixture = make_fixture();
+      let server = MockServer::start().await;
+
+      Mock::given(method("GET"))
+         .and(wm_path("/file"))
+         .respond_with(ResponseTemplate::new(200).set_body_bytes(b"body".to_vec()))
+         .mount(&server)
+         .await;
+
+      let dest = dest_path(&fixture, "file.bin");
+      let url = format!("{}/file", server.uri());
+      let item = seed_in_progress(&fixture.manager, &dest, &url);
+
+      download(&fixture.manager, item).await.unwrap();
+
+      assert_eq!(received_user_agent(&server).await, None);
+   }
+
+   #[tokio::test]
+   async fn test_an_unusable_user_agent_is_dropped_rather_than_panicking() {
+      // `DownloadManager::new` is public on a Tauri-agnostic crate, so it cannot
+      // assume the caller validated first the way the Tauri plugin does. An unusable
+      // value is dropped with a warning instead of panicking the constructor.
+      let fixture = make_fixture_with_config(DownloadManagerConfig {
+         user_agent: Some("bad\nvalue".to_string()),
+      });
+      let server = MockServer::start().await;
+
+      Mock::given(method("GET"))
+         .and(wm_path("/file"))
+         .respond_with(ResponseTemplate::new(200).set_body_bytes(b"body".to_vec()))
+         .mount(&server)
+         .await;
+
+      let dest = dest_path(&fixture, "file.bin");
+      let url = format!("{}/file", server.uri());
+      let item = seed_in_progress(&fixture.manager, &dest, &url);
+
+      download(&fixture.manager, item).await.unwrap();
+
+      assert_eq!(received_user_agent(&server).await, None);
+   }
+
+   /// A configured user agent must not displace the `Range` header the resume path
+   /// sets: `.headers(...)` replaces the per-request map, not the client default.
+   #[tokio::test]
+   async fn test_user_agent_and_range_header_are_both_sent_on_resume() {
+      let fixture = make_fixture_with_config(DownloadManagerConfig {
+         user_agent: Some("my-app/1.0".to_string()),
+      });
+      let server = MockServer::start().await;
+
+      Mock::given(method("GET"))
+         .and(wm_path("/file"))
+         .and(header("Range", "bytes=4-"))
+         .and(header("user-agent", "my-app/1.0"))
+         .respond_with(ResponseTemplate::new(206).set_body_bytes(b"rest".to_vec()))
+         .expect(1)
+         .mount(&server)
+         .await;
+
+      let dest = dest_path(&fixture, "file.bin");
+      fs::write(format!("{}{}", dest, DOWNLOAD_SUFFIX), b"part").unwrap();
+
+      let url = format!("{}/file", server.uri());
+      let item = seed_in_progress(&fixture.manager, &dest, &url);
+
+      download(&fixture.manager, item).await.unwrap();
+
+      server.verify().await;
    }
 }

--- a/crates/download-manager/src/error.rs
+++ b/crates/download-manager/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
    #[error("Path Error: {0}")]
    Path(String),
 
+   #[error("User Agent Error: {0}")]
+   UserAgent(String),
+
    #[error("Network unavailable: no active connection")]
    NetworkUnavailable,
 

--- a/crates/download-manager/src/lib.rs
+++ b/crates/download-manager/src/lib.rs
@@ -6,5 +6,6 @@ mod store;
 mod validate;
 
 pub use error::{Error, Result};
-pub use manager::{DownloadManager, OnChanged};
+pub use manager::{DownloadManager, DownloadManagerConfig, OnChanged};
 pub use models::{CreateOptions, DownloadActionResponse, DownloadItem, DownloadStatus};
+pub use validate::user_agent as validate_user_agent;

--- a/crates/download-manager/src/manager.rs
+++ b/crates/download-manager/src/manager.rs
@@ -20,6 +20,14 @@ pub(crate) static DOWNLOAD_SUFFIX: &str = ".download";
 /// Callback invoked whenever a download item changes state.
 pub type OnChanged = Arc<dyn Fn(DownloadItem) + Send + Sync + 'static>;
 
+/// Manager-wide settings, fixed when the manager is constructed.
+#[derive(Debug, Clone, Default)]
+pub struct DownloadManagerConfig {
+   /// User agent sent with every download request. `None` leaves the transport's
+   /// own default in place.
+   pub user_agent: Option<String>,
+}
+
 /// Tauri-agnostic download manager, mirroring the iOS/Android `DownloadManager`.
 #[derive(Clone)]
 pub struct DownloadManager {
@@ -35,7 +43,8 @@ impl DownloadManager {
    /// # Arguments
    /// - `data_dir` - Directory where `downloads.json` will be stored.
    /// - `on_changed` - Callback invoked on every state/progress change.
-   pub fn new(data_dir: PathBuf, on_changed: OnChanged) -> Self {
+   /// - `config` - Manager-wide settings.
+   pub fn new(data_dir: PathBuf, on_changed: OnChanged, config: DownloadManagerConfig) -> Self {
       #[cfg(target_os = "macos")]
       {
          // Start the path monitor early so its initial asynchronous update has
@@ -46,6 +55,7 @@ impl DownloadManager {
       Self::with_connection_status_provider(
          data_dir,
          on_changed,
+         config,
          Arc::new(connectivity::connection_status),
       )
    }
@@ -53,6 +63,7 @@ impl DownloadManager {
    fn with_connection_status_provider(
       data_dir: PathBuf,
       on_changed: OnChanged,
+      config: DownloadManagerConfig,
       connection_status: ConnectionStatusProvider,
    ) -> Self {
       let store = DownloadStore::new(data_dir.join("downloads.json"));
@@ -61,7 +72,25 @@ impl DownloadManager {
       }
       // Build client with retry middleware for transient failures.
       let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
-      let http_client = ClientBuilder::new(reqwest::Client::new())
+
+      let mut client_builder = reqwest::Client::builder();
+      if let Some(ref user_agent) = config.user_agent {
+         // Checked rather than trusted: a public constructor cannot assume its caller
+         // validated, and an unusable value would panic the build below. A direct
+         // consumer gets no user agent and no warning — `release_max_level_off` elides it.
+         match validate::user_agent(user_agent) {
+            Ok(()) => client_builder = client_builder.user_agent(user_agent.clone()),
+            Err(e) => warn!("Ignoring invalid user agent: {}", e),
+         }
+      }
+
+      // Mirrors `reqwest::Client::new()`, which expects on the same builder. With the
+      // user agent checked above, only a TLS or resolver failure can reach this.
+      let client = client_builder
+         .build()
+         .expect("Failed to build the download HTTP client");
+
+      let http_client = ClientBuilder::new(client)
          .with(RetryTransientMiddleware::new_with_policy(retry_policy))
          .build();
       Self {
@@ -453,6 +482,13 @@ mod tests {
    fn make_manager_with_provider(
       connection_status: impl Fn() -> connectivity::Result<ConnectionStatus> + Send + Sync + 'static,
    ) -> (DownloadManager, TempDir, EventLog) {
+      make_manager_with_config(DownloadManagerConfig::default(), connection_status)
+   }
+
+   fn make_manager_with_config(
+      config: DownloadManagerConfig,
+      connection_status: impl Fn() -> connectivity::Result<ConnectionStatus> + Send + Sync + 'static,
+   ) -> (DownloadManager, TempDir, EventLog) {
       let dir = TempDir::new().unwrap();
       let events: EventLog = Arc::new(Mutex::new(Vec::new()));
       let captured = events.clone();
@@ -462,6 +498,7 @@ mod tests {
       let manager = DownloadManager::with_connection_status_provider(
          dir.path().to_path_buf(),
          on_changed,
+         config,
          Arc::new(connection_status),
       );
       (manager, dir, events)

--- a/crates/download-manager/src/validate.rs
+++ b/crates/download-manager/src/validate.rs
@@ -59,6 +59,29 @@ pub fn url(url: &str) -> crate::Result<()> {
    Ok(())
 }
 
+/// Validates an HTTP user agent.
+///
+/// Accepts printable ASCII and horizontal tab — what all three transports accept, and
+/// narrower than reqwest's own `HeaderValue` rule, which admits the UTF-8 bytes of a
+/// non-ASCII character only for OkHttp to reject them on every Android download.
+///
+/// No emptiness check, unlike [`path`] and [`url`]: an empty user agent is legal HTTP,
+/// and refusing it would be this crate's policy, not the specification's.
+pub fn user_agent(user_agent: &str) -> crate::Result<()> {
+   let invalid = user_agent
+      .chars()
+      .find(|&c| c != '\t' && c != ' ' && !c.is_ascii_graphic());
+
+   if let Some(c) = invalid {
+      return Err(Error::UserAgent(format!(
+         "Invalid user agent: {:?} is not printable ASCII",
+         c
+      )));
+   }
+
+   Ok(())
+}
+
 #[cfg(test)]
 mod tests {
    use super::*;
@@ -123,5 +146,50 @@ mod tests {
       assert!(url("not a valid url").is_err());
       // Protocol-relative URL with no scheme.
       assert!(url("//example.com/file.mp4").is_err());
+   }
+
+   #[test]
+   fn test_valid_user_agents() {
+      assert!(user_agent("my-app/1.0").is_ok());
+      assert!(user_agent("MyApp/2.1 (Linux; x86_64) build/1234").is_ok());
+      // A single token with no version is unusual but legal.
+      assert!(user_agent("curl").is_ok());
+   }
+
+   #[test]
+   fn test_user_agent_with_an_internal_tab_is_accepted() {
+      // Tab is the one non-graphic character OkHttp's `checkValue` admits, so the
+      // accepted set matches it exactly. Without this case, dropping the tab arm of
+      // the filter changes no test outcome.
+      assert!(user_agent("my-app/1.0 (build\t1)").is_ok());
+   }
+
+   #[test]
+   fn test_empty_user_agent_is_accepted() {
+      // Characterisation test, not a design goal: an empty header value is legal
+      // HTTP, so the rule delegated to `HeaderValue` admits it. Rejecting it would
+      // be a policy this crate invented.
+      assert!(user_agent("").is_ok());
+   }
+
+   #[test]
+   fn test_user_agent_with_non_ascii_characters() {
+      // Accepted by `HeaderValue`, rejected by OkHttp: without this rule the value
+      // passes plugin init and then fails every Android download.
+      assert!(user_agent("Caf\u{e9}/1.0").is_err());
+      assert!(user_agent("\u{fc}ber/2.0").is_err());
+      assert!(user_agent("app/1.0 \u{2122}").is_err());
+
+      let result = user_agent("Caf\u{e9}/1.0");
+      assert!(result.unwrap_err().to_string().contains("printable ASCII"));
+   }
+
+   #[test]
+   fn test_user_agent_with_control_characters() {
+      // A newline would let a caller inject a second header, so the header value
+      // rule rejects it before the client is ever built.
+      assert!(user_agent("bad\nvalue").is_err());
+      assert!(user_agent("bad\rvalue").is_err());
+      assert!(user_agent("bad\0value").is_err());
    }
 }

--- a/examples/tauri-app/src-tauri/src/lib.rs
+++ b/examples/tauri-app/src-tauri/src/lib.rs
@@ -3,7 +3,11 @@
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_log::Builder::default().build())
-        .plugin(tauri_plugin_download::init())
+        .plugin(
+            tauri_plugin_download::Builder::new()
+                .user_agent("tauri-app/0.1.0")
+                .build(),
+        )
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
@@ -25,6 +25,8 @@ public final class DownloadManager: NSObject {
    }
    
    let downloadContinuation = DownloadContinuation()
+
+   private let userAgentHolder = UserAgentHolder()
    
    private var sessionDelegate: DownloadSessionDelegate!
    private var session: URLSession!
@@ -128,6 +130,22 @@ public final class DownloadManager: NSObject {
    }
    
    /**
+    Sets the user agent sent with every download request.
+
+    Applied per request, not on the session configuration: the background session is
+    built in `init()` before any value can arrive, and is not one to recreate at
+    runtime. Same reason the network policy is per request.
+
+    The holder is tested; that `start(path:)` and `resume(path:)` read it is not, and
+    cannot be until this package can intercept the session's requests.
+
+    - Parameter userAgent: The user agent, or `nil` to leave URLSession's default.
+    */
+   public func setUserAgent(_ userAgent: String?) async {
+      await userAgentHolder.set(userAgent)
+   }
+
+   /**
     Starts a download operation.
 
     - Parameter path: The download path.
@@ -150,7 +168,8 @@ public final class DownloadManager: NSObject {
       record.setStatus(.inProgress)
       await store.update(record)
 
-      let task = session.downloadTask(with: Self.request(for: record))
+      let request = Self.request(for: record, userAgent: await userAgentHolder.value)
+      let task = session.downloadTask(with: request)
       task.taskDescription = path.path
       task.resume()
       
@@ -189,9 +208,10 @@ public final class DownloadManager: NSObject {
 
       if let resumeData, !resumeData.isEmpty {
          // The one task this manager creates without building the request: resume
-         // data carries the original NSURLRequest, so the policy set by request(for:)
-         // at start() survives. Confirmed on device, but Apple does not document
-         // resume data as preserving request properties — re-check on new iOS majors.
+         // data carries the original NSURLRequest, so the policy and user agent set
+         // by request(for:) at start() survive. Confirmed on device, but Apple does
+         // not document resume data as preserving request properties — re-check on
+         // new iOS majors.
          task = session.downloadTask(withResumeData: resumeData)
       } else {
          os_log(.info, log: Log.downloadManager,
@@ -204,7 +224,8 @@ public final class DownloadManager: NSObject {
          record.setBytes(received: 0, total: record.totalBytes)
          await store.update(record)
 
-         task = session.downloadTask(with: Self.request(for: record))
+         let request = Self.request(for: record, userAgent: await userAgentHolder.value)
+         task = session.downloadTask(with: request)
       }
 
       task.taskDescription = path.path
@@ -483,7 +504,7 @@ public final class DownloadManager: NSObject {
    /// A restricted task is not rejected: a background session waits for a path
    /// that satisfies the request and starts transferring once one appears.
    /// Desktop, having no such scheduler, rejects `start()`/`resume()` instead.
-   static func request(for record: DownloadRecord) -> URLRequest {
+   static func request(for record: DownloadRecord, userAgent: String?) -> URLRequest {
       var request = URLRequest(url: record.url)
       let allowMetered = record.options.allowMetered
 
@@ -494,6 +515,10 @@ public final class DownloadManager: NSObject {
       request.allowsCellularAccess = allowMetered
       request.allowsExpensiveNetworkAccess = allowMetered
       request.allowsConstrainedNetworkAccess = allowMetered
+
+      if let userAgent {
+         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+      }
 
       return request
    }

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/UserAgentHolder.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/UserAgentHolder.swift
@@ -1,0 +1,19 @@
+//
+//  UserAgentHolder.swift
+//  DownloadManagerKit
+//
+
+import Foundation
+
+/// Holds the user agent sent with every download request.
+///
+/// An actor rather than a stored property on [`DownloadManager`], which is a class
+/// and not isolated: the value is written from the Tauri plugin's command and read
+/// from the tasks that build requests.
+actor UserAgentHolder {
+   private(set) var value: String?
+
+   func set(_ userAgent: String?) {
+      value = userAgent
+   }
+}

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadManagerTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadManagerTests.swift
@@ -142,7 +142,7 @@ final class DownloadManagerTests: XCTestCase {
    }
 
    func testUnrestrictedRequestLeavesEveryPathAllowed() {
-      let request = DownloadManager.request(for: idleRecord(allowMetered: true))
+      let request = DownloadManager.request(for: idleRecord(allowMetered: true), userAgent: nil)
 
       XCTAssertEqual(request.url, URL(string: "http://example.com/file.mp4"))
       XCTAssertTrue(request.allowsCellularAccess)
@@ -154,11 +154,54 @@ final class DownloadManagerTests: XCTestCase {
       // All three, not just allowsCellularAccess: expensive covers personal
       // hotspots and constrained covers Low Data Mode, which together match the
       // desktop check that rejects a metered *or* constrained connection.
-      let request = DownloadManager.request(for: idleRecord(allowMetered: false))
+      let request = DownloadManager.request(for: idleRecord(allowMetered: false), userAgent: nil)
 
       XCTAssertEqual(request.url, URL(string: "http://example.com/file.mp4"))
       XCTAssertFalse(request.allowsCellularAccess)
       XCTAssertFalse(request.allowsExpensiveNetworkAccess)
       XCTAssertFalse(request.allowsConstrainedNetworkAccess)
+   }
+
+   func testConfiguredUserAgentIsSetOnTheRequest() {
+      let request = DownloadManager.request(
+         for: idleRecord(allowMetered: true),
+         userAgent: "my-app/1.0"
+      )
+
+      XCTAssertEqual(request.value(forHTTPHeaderField: "User-Agent"), "my-app/1.0")
+   }
+
+   func testNoUserAgentLeavesTheHeaderUnset() {
+      // The setting is opt-in: unset must leave URLSession's own default in place
+      // rather than start sending a header the app did not ask for.
+      let request = DownloadManager.request(
+         for: idleRecord(allowMetered: true),
+         userAgent: nil
+      )
+
+      XCTAssertNil(request.value(forHTTPHeaderField: "User-Agent"))
+   }
+
+   // -- User agent holder --
+
+   func testUserAgentHolderStoresTheValue() async {
+      let holder = UserAgentHolder()
+
+      await holder.set("my-app/1.0")
+
+      let value = await holder.value
+      XCTAssertEqual(value, "my-app/1.0")
+   }
+
+   func testUserAgentHolderOverwritesAnEarlierValue() async {
+      // A holder that latched its first value would pass the test above and still
+      // send a stale user agent for the rest of the process.
+      let holder = UserAgentHolder()
+
+      await holder.set("my-app/1.0")
+      await holder.set(nil)
+
+      let value = await holder.value
+      XCTAssertNil(value)
    }
 }

--- a/ios/Sources/DownloadPlugin.swift
+++ b/ios/Sources/DownloadPlugin.swift
@@ -7,6 +7,14 @@ class PathArgs: Decodable {
    let path: String
 }
 
+/// Settings pushed by the Rust plugin at startup.
+///
+/// Named for the payload rather than the setting so a second builder option is a new
+/// field here, not a second command.
+class ConfigArgs: Decodable {
+   let userAgent: String
+}
+
 class CreateArgs: Decodable {
    let path: String
    let url: String
@@ -26,6 +34,22 @@ class DownloadPlugin: Plugin {
              Logger.debug("[\(download.path.lastPathComponent)] \(download.status) - \(String(format: "%.0f", download.progress))% (\(download.receivedBytes)/\(download.totalBytes.map { String($0) } ?? "unknown") bytes)")
 #endif
           }
+      }
+   }
+
+   /// Applies the settings from the Rust plugin's builder.
+   ///
+   /// Invoked by the Rust plugin during setup rather than from the webview: Tauri
+   /// fills the config it hands to `load(webview:)` from `tauri.conf.json`, so a
+   /// value set on the Rust builder can only arrive as a command.
+   @objc public func configure(_ invoke: Invoke) throws {
+      let args = try invoke.parseArgs(ConfigArgs.self)
+      Task {
+         await self.downloadManager.setUserAgent(args.userAgent)
+         // No response payload anchors this call inside the Task the way every other
+         // handler's does, so hoisting it out would still compile — and would let
+         // Rust's blocking `run_mobile_plugin` return before the actor write lands.
+         invoke.resolve()
       }
    }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use tauri::{
    Manager, RunEvent, Runtime,
-   plugin::{Builder, TauriPlugin},
+   plugin::{self, TauriPlugin},
 };
 
 #[cfg(desktop)]
@@ -17,7 +17,7 @@ pub use models::CreateOptions;
 use error::Result;
 
 #[cfg(desktop)]
-use download_manager::DownloadManager;
+use download_manager::{DownloadManager, DownloadManagerConfig};
 
 #[cfg(mobile)]
 mod mobile;
@@ -56,56 +56,144 @@ impl<R: Runtime, T: Manager<R>> crate::DownloadExt<R> for T {
    }
 }
 
-/// Initializes the plugin.
-pub fn init<R: Runtime>() -> TauriPlugin<R> {
-   Builder::new("download")
-      .invoke_handler(tauri::generate_handler![
-         commands::create,
-         commands::list,
-         commands::get,
-         commands::start,
-         commands::cancel,
-         commands::pause,
-         commands::resume,
-         commands::is_native,
-      ])
-      .setup(|app, _api| {
-         #[cfg(desktop)]
-         {
-            // Resolve the app data directory for store persistence.
-            let data_dir = app.path().app_data_dir().unwrap_or_else(|e| {
-               warn!("Failed to resolve app data dir, falling back to '.': {}", e);
-               std::path::PathBuf::from(".")
-            });
+/// Plugin builder for configuring the download manager before initialization.
+///
+/// # Examples
+///
+/// ```no_run
+/// tauri::Builder::default()
+///    .plugin(
+///       tauri_plugin_download::Builder::new()
+///          .user_agent("my-app/1.0")
+///          .build(),
+///    );
+/// ```
+#[derive(Debug, Default)]
+pub struct Builder {
+   user_agent: Option<String>,
+}
 
-            // Wire Tauri event emission as the on_changed callback.
-            let app_handle = app.app_handle().clone();
-            let manager = DownloadManager::new(
-               data_dir,
-               std::sync::Arc::new(move |item| {
-                  if let Err(e) = app_handle.emit("tauri-plugin-download:changed", &item) {
-                     warn!("Failed to emit change event: {}", e);
-                  }
-               }),
-            );
-            app.manage(manager);
-         }
+impl Builder {
+   /// Creates a new builder, leaving every platform's own defaults in place.
+   pub fn new() -> Self {
+      Self::default()
+   }
 
-         #[cfg(mobile)]
-         {
-            // Mobile download management is handled natively by the platform plugin.
-            let download = mobile::init(app, _api)?;
-            app.manage(download);
-         }
+   /// Sets the `User-Agent` header sent with every download request.
+   ///
+   /// Applies on desktop, Android and iOS; unset, each keeps what its own HTTP stack
+   /// sends. Must be printable ASCII or horizontal tab — the rule all three accept.
+   /// Anything else fails plugin initialization rather than surfacing later as a
+   /// failed download on one platform.
+   pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+      self.user_agent = Some(user_agent.into());
+      self
+   }
 
-         Ok(())
-      })
-      .on_event(|_app_handle, event| {
-         if let RunEvent::Ready = event {
-            // Initialize the download plugin.
+   /// Builds the Tauri plugin with the configured settings.
+   pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
+      let user_agent = self.user_agent;
+
+      plugin::Builder::new("download")
+         .invoke_handler(tauri::generate_handler![
+            commands::create,
+            commands::list,
+            commands::get,
+            commands::start,
+            commands::cancel,
+            commands::pause,
+            commands::resume,
+            commands::is_native,
+         ])
+         .setup(move |app, _api| {
+            // Validated before either platform branch so an invalid value fails the
+            // same way everywhere, rather than only where the transport rejects it.
+            if let Some(ref user_agent) = user_agent {
+               download_manager::validate_user_agent(user_agent)?;
+            }
+
             #[cfg(desktop)]
-            _app_handle.state::<DownloadManager>().init();
-         }
-      })
-      .build()
+            {
+               // Resolve the app data directory for store persistence.
+               let data_dir = app.path().app_data_dir().unwrap_or_else(|e| {
+                  warn!("Failed to resolve app data dir, falling back to '.': {}", e);
+                  std::path::PathBuf::from(".")
+               });
+
+               // Wire Tauri event emission as the on_changed callback.
+               let app_handle = app.app_handle().clone();
+               let manager = DownloadManager::new(
+                  data_dir,
+                  std::sync::Arc::new(move |item| {
+                     if let Err(e) = app_handle.emit("tauri-plugin-download:changed", &item) {
+                        warn!("Failed to emit change event: {}", e);
+                     }
+                  }),
+                  DownloadManagerConfig { user_agent },
+               );
+               app.manage(manager);
+            }
+
+            #[cfg(mobile)]
+            {
+               // Mobile download management is handled natively by the platform plugin.
+               let download = mobile::init(app, _api, user_agent)?;
+               app.manage(download);
+            }
+
+            Ok(())
+         })
+         .on_event(|_app_handle, event| {
+            if let RunEvent::Ready = event {
+               // Initialize the download plugin.
+               #[cfg(desktop)]
+               _app_handle.state::<DownloadManager>().init();
+            }
+         })
+         .build()
+   }
+}
+
+/// Initializes the plugin with default settings.
+///
+/// Use [`Builder`] to configure it.
+pub fn init<R: Runtime>() -> TauriPlugin<R> {
+   Builder::new().build()
+}
+
+#[cfg(test)]
+mod tests {
+   use super::*;
+
+   #[test]
+   fn test_user_agent_setter_stores_the_value() {
+      // Not tautological: the field is read once, in `build`, and a setter that
+      // dropped its argument would leave every download on the platform default with
+      // nothing failing.
+      let builder = Builder::new().user_agent("my-app/1.0");
+
+      assert_eq!(builder.user_agent, Some("my-app/1.0".to_string()));
+   }
+
+   #[test]
+   fn test_an_invalid_user_agent_fails_plugin_initialization() {
+      // The promise the README makes. `validate_user_agent` runs ahead of the
+      // desktop/mobile split, so this resolves on any host without a mobile target.
+      let app = tauri::test::mock_builder()
+         .plugin(Builder::new().user_agent("Caf\u{e9}/1.0").build())
+         .build(tauri::test::mock_context(tauri::test::noop_assets()));
+
+      assert!(matches!(app, Err(tauri::Error::PluginInitialization(_, _))));
+   }
+
+   #[test]
+   fn test_a_valid_user_agent_initializes() {
+      // Pairs with the case above: without it, any unrelated setup failure would
+      // satisfy that assertion.
+      let app = tauri::test::mock_builder()
+         .plugin(Builder::new().user_agent("my-app/1.0").build())
+         .build(tauri::test::mock_context(tauri::test::noop_assets()));
+
+      assert!(app.is_ok());
+   }
 }

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -13,18 +13,60 @@ tauri::ios_plugin_binding!(init_plugin_download);
 pub fn init<R: Runtime, C: DeserializeOwned>(
    _app: &AppHandle<R>,
    _api: PluginApi<R, C>,
+   user_agent: Option<String>,
 ) -> crate::Result<Download<R>> {
    #[cfg(target_os = "android")]
    let handle = _api.register_android_plugin(PLUGIN_IDENTIFIER, "DownloadPlugin")?;
    #[cfg(target_os = "ios")]
    let handle = _api.register_ios_plugin(init_plugin_download)?;
-   Ok(Download(handle))
+
+   let download = Download(handle);
+
+   // Pushed because the plugin config Tauri forwards to `load()` comes from
+   // `tauri.conf.json`, so a builder value cannot ride it. Registration blocks and
+   // runs inside `Builder::build`, before `App::run` creates any webview.
+   //
+   // What keeps `configure` unreachable from JS is the ACL, not its absence from
+   // `generate_handler!` — absence is what routes to native, as `registerListener`
+   // does. The invariant is that `configure` never enters COMMANDS.
+   //
+   // A transport failure aborts launch, deliberately: with `release_max_level_off`,
+   // "log and continue" would ship the wrong agent silently.
+   if let Some(user_agent) = user_agent {
+      download.configure(&user_agent)?;
+   }
+
+   Ok(download)
 }
 
 /// Access to the download APIs.
 pub struct Download<R: Runtime>(PluginHandle<R>);
 
 impl<R: Runtime> Download<R> {
+   ///
+   /// Pushes the builder's settings to the native plugin.
+   ///
+   /// Deliberately not public: it is only correct to call once, before any download
+   /// exists. A later change would reach Android only for work enqueued after it and
+   /// iOS only for newly created tasks, which is not a contract worth offering.
+   ///
+   /// # Arguments
+   /// - `user_agent` - The user agent sent with every download request.
+   ///
+   fn configure(&self, user_agent: &str) -> crate::Result<()> {
+      // A bare `invoke.resolve()` sends the literal `null` on both platforms, which
+      // is what `()` decodes from. Anything else here would fail to deserialize.
+      self
+         .0
+         .run_mobile_plugin(
+            "configure",
+            ConfigArgs {
+               user_agent: user_agent.to_string(),
+            },
+         )
+         .map_err(Into::into)
+   }
+
    ///
    /// Initializes the API.
    /// Updates the state of any download operations which are still marked as "In Progress". This can occur if the

--- a/src/models.rs
+++ b/src/models.rs
@@ -36,6 +36,16 @@ mod mobile_types {
       pub path: String,
    }
 
+   /// Settings pushed to the native plugin once at startup.
+   ///
+   /// Named for the payload rather than the setting so a second builder option is a
+   /// new field here, not a second command mirrored across Kotlin and Swift.
+   #[derive(Serialize)]
+   #[serde(rename_all = "camelCase")]
+   pub struct ConfigArgs {
+      pub user_agent: String,
+   }
+
    #[derive(Serialize)]
    #[serde(rename_all = "camelCase")]
    pub struct CreateArgs {
@@ -99,7 +109,9 @@ mod mobile_types {
 }
 
 #[cfg(mobile)]
-pub use mobile_types::{CreateArgs, CreateOptions, DownloadActionResponse, DownloadItem, PathArgs};
+pub use mobile_types::{
+   ConfigArgs, CreateArgs, CreateOptions, DownloadActionResponse, DownloadItem, PathArgs,
+};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Refs #61.

No user agent was set anywhere, so each transport sent its own: nothing on desktop, `okhttp/4.12.0` on Android, `<app>/<version> CFNetwork/…` on iOS. A plugin builder now sets one for all three:

```rust
tauri_plugin_download::Builder::new()
   .user_agent("my-app/1.0")
   .build()
```

`init()` stays as shorthand for `Builder::new().build()`. Left unset, each platform keeps what it sends today.

### Getting the value to the native plugins

Tauri builds the config it forwards to a native `load()` from `tauri.conf.json` (`tauri-2.9.5/src/plugin.rs:799`), so a value set on the Rust builder cannot travel that channel. It is pushed with a `configure` command from plugin `setup()` instead — after registration, and before the event loop exists, so before the webview can invoke anything. `run_mobile_plugin` bypasses the ACL, so `configure` needs no `COMMANDS` entry or permission and is unreachable from JS.

Raised upstream as tauri-apps/tauri#15925, proposing that `PluginApi` gain a way to pass builder-supplied config to the native side. If that lands, the `configure` command can be dropped from both Kotlin and Swift and the value read through the existing `getConfig` / `parseConfig` instead.

Desktop configures its one `reqwest` client. iOS sets the header per request, because the background session is built in `init()` before any value can arrive. Android captures it into the WorkManager input data at enqueue time — WorkManager can re-run a stranded worker in a process where the plugin never loads, so an in-memory value would be lost.

### Validation is printable ASCII, not the full header spec

`HeaderValue` accepts the UTF-8 bytes of non-ASCII characters; OkHttp's `checkValue` does not. So `.user_agent("Café/1.0")` would pass startup, work on desktop and iOS, and throw in `DownloadWorker` on every Android download — into the permanent-failure branch, since `IllegalArgumentException` is not an `IOException`. Confirmed against the project's own OkHttp: `Unexpected char 0xe9 at 3`. Empty is accepted, being legal HTTP.

### Notes for review

* A changed user agent reaches in-flight downloads differently per platform: fixed at enqueue time on Android and at start on iOS, while desktop's one-client-per-process means a resumed download picks up the new value. All three are in the README.
* The Kotlin bridge is compile-checked nowhere — it needs `android/.tauri/tauri-api`, which only exists during a real app build, and CI runs `:lib:test`. Inspection-verified only.
* Not run on device. The case worth exercising is force-stopping mid-download on Android and letting WorkManager re-run the worker.
* `await userAgentHolder.value` widens a pre-existing iOS window between the `.inProgress` commit and task creation, where a concurrent `cancel()` orphans the download. Not new — `await store.update(record)` was already a suspension point there. Closing it means serialising start/cancel per path, which is not this change's job.
