### PR TITLE
feat: allow configuring the download store location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4104,6 +4104,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
+ "tempfile",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ tauri-plugin = { version = "2.5.1", features = ["build"] }
 
 [dev-dependencies]
 serde_json = "1.0.145"
+tempfile = "3.26.0"
 tauri = { version = "2.9.3", features = ["test"] }

--- a/README.md
+++ b/README.md
@@ -120,52 +120,65 @@ fn main() {
 Use `Builder` instead of `init()` to configure the plugin. `init()` is shorthand for
 `Builder::new().build()`.
 
-```rust
-fn main() {
-   tauri::Builder::default()
-      .plugin(
-         tauri_plugin_download::Builder::new()
-            .user_agent("my-app/1.0")
-            .build(),
-      )
-      .run(tauri::generate_context!())
-      .expect("error while running tauri application");
-}
-```
+#### Builder options
 
 | Method | Type | Default | Description |
 | --- | --- | --- | --- |
 | `user_agent` | `impl Into<String>` | None | `User-Agent` sent with every download request |
+| `on_setup` | `FnOnce(&AppHandle, &mut SetupConfig) -> Result<(), Box<dyn Error>>` | None | Hook for settings that need the app instance |
 
-#### User agent
+#### Setup options
 
-The setting is opt-in. Leaving it unset keeps whatever each platform's own HTTP stack
-sends, which is not the same on all three:
+Set inside `on_setup`, which runs once the app exists and `app.path()` is available:
 
-| Platform | Transport | User agent when unset |
+| Method | Type | Default | Description |
+| --- | --- | --- | --- |
+| `store_dir` | `impl Into<PathBuf>` | Platform-specific | Directory holding `downloads.json` |
+
+Full example:
+
+```rust
+use tauri::Manager;
+
+let plugin = tauri_plugin_download::Builder::new()
+   .user_agent("my-app/1.0")
+   .on_setup(|app, config| {
+      config.store_dir(app.path().app_data_dir()?.join("downloads"));
+      Ok(())
+   })
+   .build();
+```
+
+#### Platform defaults
+
+Both settings are opt-in. Left unset, each platform keeps its own:
+
+| Platform | Store location | User agent |
 | --- | --- | --- |
-| Desktop | `reqwest` | none |
-| Android | OkHttp | `okhttp/<version>` |
-| iOS | `URLSession` | `<app>/<version> CFNetwork/… Darwin/…` |
+| Desktop | `app_data_dir()/downloads.json` | none |
+| Android | `filesDir/downloads.json` | `okhttp/<version>` |
+| iOS | `Documents/downloads.json` | `<app>/<version> CFNetwork/… Darwin/…` |
 
-Setting it makes all three send the same value. It must be printable ASCII or a
-horizontal tab — Android's HTTP client rejects anything above `~`, so that is the rule
-all three share. An invalid value fails plugin initialization rather than surfacing
-later as a failed download on one platform. An empty value is accepted — it is legal
-HTTP, and sends an empty header rather than none.
+Key behaviors:
 
-A download that outlives the process picks up a changed user agent differently on each
-platform:
+   * **The store is not migrated.** Changing `store_dir` in a later release leaves the
+     old records where they are, invisible to the plugin — treat it as discarding the
+     download history
+   * `store_dir` must be absolute, and on mobile inside the app sandbox; a relative path
+     fails plugin initialization
+   * **Keep `store_dir` on internal storage on Android.** The store lists every
+     download's URL and local path, so on external or shared storage it is readable by
+     any app holding storage access on pre-scoped-storage devices. The default,
+     `filesDir`, is app-private
+   * The directory need not exist — the store creates it on the first write
+   * Returning `Err` from `on_setup` aborts startup
+   * `user_agent` must be printable ASCII or horizontal tab, the rule all three HTTP
+     stacks share; anything else fails plugin initialization
+   * An empty `user_agent` is accepted and sends an empty header rather than none
+   * A download resumed after a relaunch uses the new run's user agent on desktop and
+     Android; iOS keeps the value the download started with when it resumes from resume
+     data
 
-   * **Desktop** builds one HTTP client per process, so a download resumed after a
-     relaunch uses the new run's value.
-   * **Android** reads the current value whenever a download is enqueued, an explicit
-     `resume` included, so it behaves like desktop. Only when WorkManager re-runs a
-     stranded worker itself — in a process where the plugin never loaded — does it fall
-     back to the value captured in the work request.
-   * **iOS** keeps the value a download started with when it resumes from resume data,
-     which carries the original request. Without resume data — from a server with no
-     byte-range support, say — it restarts from zero and picks up the current value.
 
 ### API
 
@@ -461,15 +474,14 @@ and run on an emulator or device.
 
 ### Testing the Network Policy
 
-No SIM is needed: mark the Wi-Fi network as metered from its settings page — under
-Network & internet on stock Android, Connections on One UI — where the option reads
-"Treat as metered" or "Metered". The
-example app's "Allow metered networks" toggle sets `allowMetered` on the downloads it
-creates, and each row shows the policy it was created with.
+No SIM needed. Mark the Wi-Fi network as metered from its settings page — Network &
+internet on stock Android, Connections on One UI — where the option reads "Treat as
+metered". The example app's "Allow metered networks" toggle sets `allowMetered` on the
+downloads it creates.
 
-With the toggle off, a download started on a metered network holds at zero bytes and
-begins once the network is marked unmetered. Marking the network metered mid-transfer
-stalls it, and it continues by itself a backoff delay later.
+With the toggle off, a download holds at zero bytes until the network is marked
+unmetered. Marking it metered mid-transfer stalls the download; it continues by itself
+a backoff delay later.
 
 ## iOS Support
 
@@ -492,20 +504,19 @@ select a simulator or device, and run.
 
 ### Testing the Network Policy
 
-No SIM is needed, but a real device is: Low Data Mode cannot be set on a simulator.
+No SIM needed, but a real device is — Low Data Mode cannot be set on a simulator.
 Toggle it under Settings → Wi-Fi → the ⓘ beside your network → Low Data Mode, which
 trips `allowsConstrainedNetworkAccess`. The example app's "Allow metered networks"
-toggle sets `allowMetered` on the downloads it creates, and each row shows the policy
-it was created with.
+toggle sets `allowMetered` on the downloads it creates.
 
-With the toggle off, a download started in Low Data Mode holds at zero bytes and
-begins once Low Data Mode is off. Turning it on mid-transfer stalls the download
-without leaving `inProgress`, and it continues by itself once it is off again.
+With the toggle off, a download holds at zero bytes until Low Data Mode is off.
+Turning it on mid-transfer stalls the download without leaving `inProgress`; it
+continues by itself once off again.
 
 Worth repeating on new iOS majors: pause a restricted download, turn Low Data Mode on,
-then resume. It should stay stalled. Resuming goes through
+then resume — it should stay stalled. Resume goes through
 `downloadTask(withResumeData:)`, which carries the policy in undocumented resume data,
-so this is the check that catches a silent regression there.
+so this is the check that catches a silent regression.
 
 ### Tauri Apps
 

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadManager.kt
@@ -21,8 +21,8 @@ import java.io.File
  *
  * Mirrors the iOS DownloadManager and Rust Download<R> API surface.
  */
-class DownloadManager private constructor(context: Context) {
-   internal val store = DownloadStore(context)
+class DownloadManager private constructor(context: Context, private val storeDir: File) {
+   internal val store = DownloadStore(storeDir)
    private val workManager = WorkManager.getInstance(context)
 
    /**
@@ -254,7 +254,7 @@ class DownloadManager private constructor(context: Context) {
    private fun enqueueDownload(record: DownloadRecord) {
       val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
          .setConstraints(constraintsFor(record.options))
-         .setInputData(inputDataFor(record, userAgent))
+         .setInputData(inputDataFor(record, userAgent, storeDir))
          .addTag(WORK_TAG)
          .build()
 
@@ -271,17 +271,24 @@ class DownloadManager private constructor(context: Context) {
       /**
        * Builds the work request's input data.
        *
-       * The user agent is captured here rather than read by the worker: WorkManager
-       * can re-run a stranded worker in a fresh process with no Tauri activity, where
-       * the plugin never loads and [userAgent] is null. Only input data survives.
+       * The user agent and store directory are captured here rather than read by the
+       * worker: WorkManager can re-run a stranded worker in a fresh process with no
+       * Tauri activity, where the plugin never loads and neither has been configured.
+       * Only input data survives.
+       *
+       * The store directory matters more than the user agent does. An unconfigured
+       * worker sends the wrong `User-Agent`; one that opened the default store would
+       * write a second `downloads.json` and record every byte of progress somewhere the
+       * app never reads.
        *
        * Built here for the same reason as [constraintsFor].
        */
-      internal fun inputDataFor(record: DownloadRecord, userAgent: String?): Data =
+      internal fun inputDataFor(record: DownloadRecord, userAgent: String?, storeDir: File): Data =
          workDataOf(
             DownloadWorker.KEY_URL to record.url,
             DownloadWorker.KEY_PATH to record.path,
             DownloadWorker.KEY_USER_AGENT to userAgent,
+            DownloadWorker.KEY_STORE_DIR to storeDir.absolutePath,
          )
 
       /**
@@ -340,13 +347,45 @@ class DownloadManager private constructor(context: Context) {
       /**
        * Returns the singleton DownloadManager instance.
        * Must be called with an application context.
+       *
+       * @param context The application context.
+       * @param storeDir The directory holding the download store, or `null` for the
+       *    app's internal storage. Honoured only when this call is the one that builds
+       *    the instance: [DownloadStore] reads its file in its own constructor and
+       *    [reconcileStoreOnInit] consumes it before this returns, so a store cannot be
+       *    moved afterwards. A later call naming a different directory is logged rather
+       *    than silently ignored — a store quietly left at the default is the failure
+       *    this parameter exists to prevent.
        */
-      fun getInstance(context: Context): DownloadManager {
-         return instance ?: synchronized(this) {
-            instance ?: DownloadManager(context.applicationContext).also {
+      @JvmOverloads
+      fun getInstance(context: Context, storeDir: File? = null): DownloadManager {
+         val existing = instance ?: synchronized(this) {
+            instance ?: DownloadManager(
+               context.applicationContext,
+               storeDir ?: defaultStoreDir(context.applicationContext),
+            ).also {
                instance = it
             }
          }
+
+         if (storeDir != null && storeDir != existing.storeDir) {
+            Log.w(
+               TAG,
+               "Ignoring store directory $storeDir; already built at ${existing.storeDir}",
+            )
+         }
+
+         return existing
       }
+
+      /**
+       * The store directory used when none is configured.
+       *
+       * Internal storage, so the store stays app-private and needs no permission.
+       *
+       * @param context The application context.
+       * @return The default store directory.
+       */
+      internal fun defaultStoreDir(context: Context): File = context.filesDir
    }
 }

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadStore.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadStore.kt
@@ -1,6 +1,5 @@
 package org.silvermine.downloadmanager
 
-import android.content.Context
 import android.util.AtomicFile
 import android.util.Log
 import kotlinx.serialization.encodeToString
@@ -13,9 +12,13 @@ import java.io.File
  * All public methods are synchronized to ensure consistency when accessed
  * from multiple threads (e.g. WorkManager workers and the main thread).
  * Mirrors the iOS DownloadStore actor pattern.
+ *
+ * @param directory The directory holding [STORE_FILENAME]. Taken rather than derived
+ *    from a Context so the location is configurable; the caller resolves the default.
+ *    Read here and nowhere else, which is why it cannot be changed after construction.
  */
-internal class DownloadStore(context: Context) {
-   private val file = AtomicFile(File(context.filesDir, STORE_FILENAME))
+internal class DownloadStore(directory: File) {
+   private val file = AtomicFile(File(directory, STORE_FILENAME))
    private val downloads = mutableMapOf<String, DownloadRecord>()
 
    init {

--- a/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
+++ b/android/lib/src/main/java/org/silvermine/downloadmanager/DownloadWorker.kt
@@ -41,7 +41,20 @@ internal class DownloadWorker(
       val url = inputData.getString(KEY_URL) ?: return Result.failure()
       val path = inputData.getString(KEY_PATH) ?: return Result.failure()
 
-      val manager = DownloadManager.getInstance(applicationContext)
+      // The store directory comes from the input data rather than the manager, for the
+      // same reason the user agent does below: a worker re-run after process death has
+      // no loaded plugin to have configured it, and would otherwise open the default
+      // store and write this download's progress where the app never reads it.
+      //
+      // Refused rather than defaulted, as the url and path above are. Only a work
+      // request enqueued before this key existed can lack it, and running it would
+      // build the process singleton at the default directory — so a plugin that
+      // configured one would be handed the wrong store for the rest of the session.
+      // The record survives: reconciliation reverts it on the next manager init, and
+      // the download can be started again.
+      val storeDir = inputData.getString(KEY_STORE_DIR)?.let { File(it) }
+         ?: return Result.failure()
+      val manager = DownloadManager.getInstance(applicationContext, storeDir)
       val store = manager.store
       val tempFile = File("$path$DOWNLOAD_SUFFIX")
 
@@ -397,6 +410,7 @@ internal class DownloadWorker(
       const val KEY_URL = "download_url"
       const val KEY_PATH = "download_path"
       const val KEY_USER_AGENT = "download_user_agent"
+      const val KEY_STORE_DIR = "download_store_dir"
 
       /**
        * Builds the download request.

--- a/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
+++ b/android/lib/src/test/java/org/silvermine/downloadmanager/DownloadManagerTest.kt
@@ -4,6 +4,7 @@ import androidx.work.NetworkType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.io.File
 
 class DownloadManagerTest {
 
@@ -87,7 +88,11 @@ class DownloadManagerTest {
 
    @Test
    fun `a configured user agent is captured in the work request`() {
-      val data = DownloadManager.inputDataFor(inProgressRecord(), userAgent = "my-app/1.0")
+      val data = DownloadManager.inputDataFor(
+         inProgressRecord(),
+         userAgent = "my-app/1.0",
+         storeDir = File("/tmp/store"),
+      )
 
       assertEquals("my-app/1.0", data.getString(DownloadWorker.KEY_USER_AGENT))
       assertEquals("http://example.com/file.mp4", data.getString(DownloadWorker.KEY_URL))
@@ -96,12 +101,34 @@ class DownloadManagerTest {
 
    @Test
    fun `no user agent stores a null value`() {
-      // The key is present with a null value, not absent: measured on work-runtime
-      // 2.9.1, `workDataOf(k to null)` gives size()==3 and containsKey()==true. Either
-      // way `getString` returns null, which the worker treats as "send no User-Agent",
-      // leaving OkHttp's default.
-      val data = DownloadManager.inputDataFor(inProgressRecord(), userAgent = null)
+      // The key is present with a null value rather than absent — asserted on `size`
+      // below rather than claimed in a comment, since `getString` returns null either
+      // way and the worker reads that as "send no User-Agent", leaving OkHttp's
+      // default. If `workDataOf` ever drops null entries, this is what catches it.
+      val data = DownloadManager.inputDataFor(
+         inProgressRecord(),
+         userAgent = null,
+         storeDir = File("/tmp/store"),
+      )
 
+      assertEquals(4, data.size())
       assertNull(data.getString(DownloadWorker.KEY_USER_AGENT))
+   }
+
+   @Test
+   fun `the store directory is captured in the work request`() {
+      // The worker opens the store from this, not from the manager: a re-run after
+      // process death has no loaded plugin to have configured one. Without the key it
+      // would open the default store and write progress where the app never reads it.
+      val data = DownloadManager.inputDataFor(
+         inProgressRecord(),
+         userAgent = null,
+         storeDir = File("/data/user/0/com.example/files/downloads"),
+      )
+
+      assertEquals(
+         "/data/user/0/com.example/files/downloads",
+         data.getString(DownloadWorker.KEY_STORE_DIR),
+      )
    }
 }

--- a/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
+++ b/android/src/main/java/org/silvermine/plugin/download/DownloadPlugin.kt
@@ -50,6 +50,7 @@ class CreateOptionsArgs {
 @InvokeArg
 class ConfigArgs {
    var userAgent: String? = null
+   var storeDir: String? = null
 }
 
 @InvokeArg
@@ -62,7 +63,24 @@ class CreateArgs {
 @TauriPlugin
 class DownloadPlugin(activity: Activity) : Plugin(activity) {
    private val json = Json { encodeDefaults = true }
-   private val downloadManager by lazy { DownloadManager.getInstance(activity.applicationContext) }
+
+   /**
+    * Held because `Plugin.activity` is `private`, so a subclass can reach it from an
+    * initializer — where the constructor parameter is still in scope — but not from a
+    * member. The application context rather than the activity, which must not outlive
+    * its own lifecycle.
+    */
+   private val appContext = activity.applicationContext
+
+   /**
+    * Computed rather than `by lazy`: [configure] has to build the instance itself, to
+    * pass the store directory into a constructor that reads it. [DownloadManager
+    * .getInstance] is already a double-checked singleton, so it — not a second lazy
+    * delegate racing with it — is the one place construction is synchronized.
+    */
+   private val downloadManager: DownloadManager
+      get() = DownloadManager.getInstance(appContext)
+
    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
    override fun load(webView: WebView) {
@@ -93,14 +111,23 @@ class DownloadPlugin(activity: Activity) : Plugin(activity) {
     * Invoked by the Rust plugin during setup rather than from the webview: Tauri
     * fills the config it hands to [load] from `tauri.conf.json`, so a value set on
     * the Rust builder can only arrive as a command.
+    *
+    * This is where the download manager is built, and that is load-bearing rather than
+    * incidental. The store directory is read by [DownloadStore]'s constructor, so it
+    * has to reach [DownloadManager.getInstance] on the call that creates the singleton.
+    * Tauri defers [load] until the webview exists, which is after plugin registration,
+    * so this command runs first — and the Rust side invokes it unconditionally, with
+    * both fields null when nothing is configured, to keep that true.
+    *
+    * Every argument is optional: absent means "keep the platform default", not a
+    * malformed call.
     */
    @Command
    fun configure(invoke: Invoke) {
       val args = invoke.parseArgs(ConfigArgs::class.java)
-      val userAgent = args.userAgent
-         ?: return invoke.reject("Missing required argument: userAgent")
+      val manager = DownloadManager.getInstance(appContext, args.storeDir?.let { File(it) })
 
-      downloadManager.userAgent = userAgent
+      args.userAgent?.let { manager.userAgent = it }
       invoke.resolve()
    }
 
@@ -160,8 +187,16 @@ class DownloadPlugin(activity: Activity) : Plugin(activity) {
       }
 
       scope.launch {
-         val response = withContext(Dispatchers.IO) { downloadManager.create(path, url, options) }
-         invoke.resolve(JSObject(json.encodeToString(response)))
+         // Guarded like every sibling command. Without this the store's own write
+         // failures — an unwritable configured directory reaches `AtomicFile.startWrite`
+         // as an IOException — escape to a scope with no handler and take the app down,
+         // where desktop returns the error to the caller.
+         try {
+            val response = withContext(Dispatchers.IO) { downloadManager.create(path, url, options) }
+            invoke.resolve(JSObject(json.encodeToString(response)))
+         } catch (e: Exception) {
+            invoke.reject(e.message)
+         }
       }
    }
 

--- a/crates/download-manager/src/lib.rs
+++ b/crates/download-manager/src/lib.rs
@@ -8,4 +8,5 @@ mod validate;
 pub use error::{Error, Result};
 pub use manager::{DownloadManager, DownloadManagerConfig, OnChanged};
 pub use models::{CreateOptions, DownloadActionResponse, DownloadItem, DownloadStatus};
+pub use validate::store_dir as validate_store_dir;
 pub use validate::user_agent as validate_user_agent;

--- a/crates/download-manager/src/validate.rs
+++ b/crates/download-manager/src/validate.rs
@@ -26,6 +26,30 @@ pub fn path(path: &str) -> crate::Result<()> {
    Ok(())
 }
 
+/// Validates a download store directory.
+///
+/// Checks that the directory:
+/// - Is not empty
+/// - Is an absolute path
+///
+/// Structural only, like [`path`]: no existence or writability check. The store creates
+/// its parent on save, and a directory writable now can stop being writable before the
+/// first write — a check here would report a state it cannot promise still holds.
+///
+/// No filename check, unlike [`path`]: every platform appends its own `downloads.json`,
+/// so a root directory is legal.
+pub fn store_dir(dir: &Path) -> crate::Result<()> {
+   if dir.as_os_str().is_empty() {
+      return Err(Error::Path("store directory cannot be empty".to_string()));
+   }
+
+   if !dir.is_absolute() {
+      return Err(Error::Path("store directory must be absolute".to_string()));
+   }
+
+   Ok(())
+}
+
 /// Validates a download URL.
 ///
 /// Checks that the URL:
@@ -109,6 +133,41 @@ mod tests {
    fn test_path_without_filename() {
       // Root path has no filename component.
       assert!(path("/").is_err());
+   }
+
+   #[test]
+   fn test_valid_store_dirs() {
+      assert!(store_dir(Path::new("/var/lib/myapp")).is_ok());
+      assert!(store_dir(Path::new("/downloads")).is_ok());
+   }
+
+   #[test]
+   fn test_empty_store_dir() {
+      let result = store_dir(Path::new(""));
+
+      assert!(result.is_err());
+      assert!(result.unwrap_err().to_string().contains("empty"));
+   }
+
+   #[test]
+   fn test_relative_store_dir() {
+      assert!(store_dir(Path::new("downloads")).is_err());
+      assert!(store_dir(Path::new("./downloads")).is_err());
+      assert!(store_dir(Path::new("../downloads")).is_err());
+   }
+
+   #[test]
+   fn test_root_store_dir_is_accepted() {
+      // Unlike `path`, which requires a filename component: the store appends its own
+      // `downloads.json`, so a directory needs no trailing component to be usable.
+      assert!(store_dir(Path::new("/")).is_ok());
+   }
+
+   #[test]
+   fn test_store_dir_is_not_required_to_exist() {
+      // The store creates its parent when it saves. Naming a directory that does not
+      // exist yet is the normal case on a first run, not a configuration error.
+      assert!(store_dir(Path::new("/nonexistent/directory/for/tests")).is_ok());
    }
 
    #[test]

--- a/examples/tauri-app/src-tauri/src/lib.rs
+++ b/examples/tauri-app/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+use tauri::Manager;
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -6,6 +8,14 @@ pub fn run() {
         .plugin(
             tauri_plugin_download::Builder::new()
                 .user_agent("tauri-app/0.1.0")
+                // A subdirectory of the app data directory rather than the directory
+                // itself, so the store is visibly somewhere the plugin was told to put
+                // it. `app.path()` resolves inside the sandbox on Android and iOS too,
+                // which a path written at the call site could not.
+                .on_setup(|app, config| {
+                    config.store_dir(app.path().app_data_dir()?.join("downloads"));
+                    Ok(())
+                })
                 .build(),
         )
         .run(tauri::generate_context!())

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadManager.swift
@@ -146,6 +146,21 @@ public final class DownloadManager: NSObject {
    }
 
    /**
+    Sets the directory holding the download store.
+
+    Static, and unlike `setUserAgent` must be called *before* `shared` is first touched:
+    the store opens its file as the manager initializes, so there is nothing left to move
+    afterwards. A late call traps in debug, and is logged and ignored in release.
+
+    Unset, the store stays in the app's Documents directory.
+
+    - Parameter url: The directory to persist the store in.
+    */
+   public static func setStoreDirectory(_ url: URL) {
+      StoreLocation.set(url)
+   }
+
+   /**
     Starts a download operation.
 
     - Parameter path: The download path.

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStore.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/DownloadStore.swift
@@ -12,13 +12,12 @@ actor DownloadStore {
    private var downloads: [DownloadRecord]
    private let savePath: URL
 
-   private static var defaultSavePath: URL {
-      FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent("downloads.json")
-   }
-
    /// - Parameter savePath: Where the store is persisted. Injectable so tests can
    ///   work against a temporary file rather than the app's Documents directory.
-   init(savePath: URL = DownloadStore.defaultSavePath) {
+   ///   Defaults through [`StoreLocation`], which is what a configured directory
+   ///   reaches this class by — the path has to be known here, since the file is read
+   ///   below rather than on first use.
+   init(savePath: URL = StoreLocation.savePath()) {
       self.savePath = savePath
       self.downloads = DownloadStore.load(from: savePath)
    }
@@ -126,6 +125,17 @@ actor DownloadStore {
       let encoder = JSONEncoder()
       do {
          let data = try encoder.encode(downloads)
+
+         // `write` does not create intermediate directories, and a configured store
+         // directory normally does not exist on a first launch. Without this, every
+         // save fails into the `catch` below and the store is never written — silently,
+         // since the in-memory array keeps serving `list` for the rest of the session.
+         // Desktop creates it in `save_inner`; Android gets it from `AtomicFile`.
+         try FileManager.default.createDirectory(
+            at: savePath.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+         )
+
          try data.write(to: savePath, options: .atomic)
       } catch {
          os_log(.error, log: Log.downloadStore, "Failed to save download store: %{public}@", error.localizedDescription)

--- a/ios/DownloadManagerKit/Sources/DownloadManagerKit/StoreLocation.swift
+++ b/ios/DownloadManagerKit/Sources/DownloadManagerKit/StoreLocation.swift
@@ -1,0 +1,74 @@
+//
+//  StoreLocation.swift
+//  DownloadManagerKit
+//
+
+import Foundation
+import os.log
+
+/// Where the download store is persisted.
+///
+/// A type-level setting rather than a parameter on [`DownloadManager`], which is a
+/// singleton built by whichever caller reaches `shared` first — and whose store opens
+/// its file in its own initializer. The directory therefore has to be settled *before*
+/// construction, and cannot be handed to it.
+///
+/// Not synchronized, because the two accesses are ordered rather than concurrent: the
+/// Tauri plugin's `configure` command sets the directory before it first touches the
+/// manager, and every later reader gets the already-constructed `shared`. The ordering
+/// comes from the happens-before edge of enqueuing that work, not from the two accesses
+/// sharing a thread — `set` runs on the plugin's IPC queue and the manager is built on
+/// the cooperative pool. A lock would imply a concurrency this design forbids.
+enum StoreLocation {
+   private static let filename = "downloads.json"
+
+   private static var directory = defaultDirectory
+   private static var isResolved = false
+
+   /// The directory used when none is configured: the app's Documents directory.
+   static var defaultDirectory: URL {
+      FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+   }
+
+   /// Sets the directory holding the store.
+   ///
+   /// Only effective before [`savePath`] is first read: once the store has opened its
+   /// file there is nothing left to move. A late call traps under `-Onone`, so a debug
+   /// build surfaces the mistake; under `-O` `assertionFailure` is compiled out and the
+   /// call degrades to the log line above and no change of directory. The guard catches
+   /// the misuse during development rather than in the build that ships.
+   ///
+   /// - Parameter url: The directory to persist the store in.
+   static func set(_ url: URL) {
+      guard !isResolved else {
+         os_log(
+            .error,
+            log: Log.downloadStore,
+            "Store directory set after the store was opened; ignoring %{public}@",
+            url.path
+         )
+         assertionFailure("StoreLocation.set called after the store was opened")
+         return
+      }
+
+      directory = url
+   }
+
+   /// The store file's full path, fixing the directory as a side effect.
+   ///
+   /// - Returns: The path the store is persisted at.
+   static func savePath() -> URL {
+      isResolved = true
+
+      return directory.appendingPathComponent(filename)
+   }
+
+   /// Restores the unconfigured state.
+   ///
+   /// Test-only: the state is process-wide, so without this one test's directory would
+   /// leak into the next and the ordering assertion would fire on the second `set`.
+   static func resetForTesting() {
+      directory = defaultDirectory
+      isResolved = false
+   }
+}

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadStoreTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/DownloadStoreTests.swift
@@ -93,6 +93,26 @@ final class DownloadStoreTests: XCTestCase {
       XCTAssertEqual(DownloadStore.load(from: savePath).first?.receivedBytes, 42)
    }
 
+   func testAppendPersistsIntoADirectoryThatDoesNotExistYet() async {
+      // The configured-store-location case, and the one `setUp`'s pre-created
+      // directory hides: `Data.write` does not create intermediate directories, so
+      // without `save` creating them every write fails into a log line while the
+      // in-memory array keeps serving `list` — the store simply never appears.
+      let directory = FileManager.default.temporaryDirectory
+         .appendingPathComponent(UUID().uuidString)
+         .appendingPathComponent("nested")
+      let path = directory.appendingPathComponent("downloads.json")
+
+      addTeardownBlock {
+         try? FileManager.default.removeItem(at: directory.deletingLastPathComponent())
+      }
+
+      let store = DownloadStore(savePath: path)
+      await store.append(record(path: "a.mp4", received: 42))
+
+      XCTAssertEqual(DownloadStore.load(from: path).first?.receivedBytes, 42)
+   }
+
    func testUpdateWithoutPersistLeavesTheFileUntouched() async throws {
       let store = DownloadStore(savePath: savePath)
       await store.append(record(path: "a.mp4", received: 42))

--- a/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/StoreLocationTests.swift
+++ b/ios/DownloadManagerKit/Tests/DownloadManagerKitTests/StoreLocationTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import DownloadManagerKit
+
+/// Covers where the store decides to persist itself.
+///
+/// `StoreLocation` is process-wide, so each test resets it on both sides. `tearDown`
+/// alone protects the tests that follow but not this class from what precedes it:
+/// XCTest orders classes arbitrarily within one process, so anything that constructs a
+/// `DownloadStore` with its default path first would leave `isResolved` set and trap
+/// the whole bundle here rather than failing one test.
+final class StoreLocationTests: XCTestCase {
+
+   override func setUp() {
+      super.setUp()
+      StoreLocation.resetForTesting()
+   }
+
+   override func tearDown() {
+      StoreLocation.resetForTesting()
+      super.tearDown()
+   }
+
+   func testTheDefaultPathIsInTheDocumentsDirectory() {
+      // The behaviour an app that configures nothing keeps. Asserting the filename
+      // alongside the directory: both platforms and the Rust store agree on it, and a
+      // change here would silently orphan every existing store.
+      let path = StoreLocation.savePath()
+
+      XCTAssertEqual(path.lastPathComponent, "downloads.json")
+      XCTAssertEqual(path.deletingLastPathComponent(), StoreLocation.defaultDirectory)
+   }
+
+   func testAConfiguredDirectoryHoldsTheStore() {
+      let directory = URL(fileURLWithPath: "/tmp/configured", isDirectory: true)
+
+      StoreLocation.set(directory)
+
+      XCTAssertEqual(StoreLocation.savePath(), directory.appendingPathComponent("downloads.json"))
+   }
+
+   func testAConfiguredDirectoryReplacesTheDefault() {
+      // Pairs with the case above: without it, a `set` that appended to the default
+      // rather than replacing it would still produce a path containing the directory.
+      let directory = URL(fileURLWithPath: "/tmp/configured", isDirectory: true)
+
+      StoreLocation.set(directory)
+
+      XCTAssertNotEqual(
+         StoreLocation.savePath().deletingLastPathComponent(),
+         StoreLocation.defaultDirectory
+      )
+   }
+
+   func testTheLastDirectorySetBeforeTheStoreOpensWins() {
+      // The plugin sets once, but nothing in the type forbids two calls before the
+      // store opens, and latching the first would be the wrong half of the contract:
+      // it is setting *after* the open that is refused.
+      StoreLocation.set(URL(fileURLWithPath: "/tmp/first", isDirectory: true))
+      StoreLocation.set(URL(fileURLWithPath: "/tmp/second", isDirectory: true))
+
+      XCTAssertEqual(StoreLocation.savePath().deletingLastPathComponent().path, "/tmp/second")
+   }
+}

--- a/ios/Sources/DownloadPlugin.swift
+++ b/ios/Sources/DownloadPlugin.swift
@@ -11,8 +11,12 @@ class PathArgs: Decodable {
 ///
 /// Named for the payload rather than the setting so a second builder option is a new
 /// field here, not a second command.
+///
+/// Every field is optional because the command is invoked unconditionally: an absent
+/// value means "keep the platform default", not a malformed call.
 class ConfigArgs: Decodable {
-   let userAgent: String
+   let userAgent: String?
+   let storeDir: String?
 }
 
 class CreateArgs: Decodable {
@@ -22,13 +26,22 @@ class CreateArgs: Decodable {
 }
 
 class DownloadPlugin: Plugin {
-   let downloadManager = DownloadManager.shared
+   /// Computed rather than stored, so constructing the plugin does not construct the
+   /// manager. `configure` has to set the store directory before anything reaches
+   /// `shared`, because the manager's store opens its file in its own initializer.
+   ///
+   /// Thread-safe lazy construction still comes from `static let shared` rather than
+   /// from a `lazy var`, which is not thread-safe on a class.
+   var downloadManager: DownloadManager { DownloadManager.shared }
 
-   override init()
-   {
-      super.init()
+   /// Subscribed here rather than in `init`, mirroring Android's `load(webView)`.
+   ///
+   /// Moving it off `init` is what keeps the manager unconstructed until `configure`
+   /// runs. Nothing is missed by waiting: `trigger` delivers to listeners registered
+   /// from JS, so before a webview exists there are none and it is already a no-op.
+   override func load(webview: WKWebView) {
       Task {
-          for await download in DownloadManager.shared.changed {
+          for await download in self.downloadManager.changed {
              try? self.trigger("changed", data: download);
 #if DEBUG
              Logger.debug("[\(download.path.lastPathComponent)] \(download.status) - \(String(format: "%.0f", download.progress))% (\(download.receivedBytes)/\(download.totalBytes.map { String($0) } ?? "unknown") bytes)")
@@ -42,8 +55,22 @@ class DownloadPlugin: Plugin {
    /// Invoked by the Rust plugin during setup rather than from the webview: Tauri
    /// fills the config it hands to `load(webview:)` from `tauri.conf.json`, so a
    /// value set on the Rust builder can only arrive as a command.
+   ///
+   /// This is also where the download manager is first built, which is load-bearing
+   /// rather than incidental. The store directory has to be set before `shared` is
+   /// touched, and Tauri defers `load(webview:)` until the webview exists — after
+   /// plugin registration — so this command runs first. The Rust side invokes it
+   /// unconditionally, with both fields nil when nothing is configured, to keep that
+   /// true and to leave the background `URLSession` restoring as early as it does now.
    @objc public func configure(_ invoke: Invoke) throws {
       let args = try invoke.parseArgs(ConfigArgs.self)
+
+      // Before the `Task`, and before any use of `downloadManager`: the manager builds
+      // its store — reading the file — during its own initialization.
+      if let storeDir = args.storeDir {
+         DownloadManager.setStoreDirectory(URL(fileURLWithPath: storeDir, isDirectory: true))
+      }
+
       Task {
          await self.downloadManager.setUserAgent(args.userAgent)
          // No response payload anchors this call inside the Task the way every other

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
+use std::path::PathBuf;
+
 use tauri::{
-   Manager, RunEvent, Runtime,
+   AppHandle, Manager, RunEvent, Runtime,
    plugin::{self, TauriPlugin},
 };
 
@@ -56,27 +58,112 @@ impl<R: Runtime, T: Manager<R>> crate::DownloadExt<R> for T {
    }
 }
 
+/// Closure type for the deferred [`Builder::on_setup`] hook.
+///
+/// Boxed error rather than [`crate::Result`]: this crate's `Error` is a different type
+/// on desktop and mobile, so neither can appear in a cross-platform signature. It is
+/// also Tauri's own `setup` return type, so `app.path().app_data_dir()?` just works.
+type OnSetupHook<R> = Box<
+   dyn FnOnce(&AppHandle<R>, &mut SetupConfig) -> std::result::Result<(), Box<dyn std::error::Error>>
+      + Send,
+>;
+
+/// Collects the settings that can only be resolved once the `app` instance exists.
+///
+/// Passed to the [`Builder::on_setup`] hook during plugin setup. Named for the payload
+/// rather than the setting, as [`ConfigArgs`](crate::models) is, so a second
+/// runtime-resolved option is a new method here rather than a second hook.
+#[derive(Debug, Default)]
+pub struct SetupConfig {
+   store_dir: Option<PathBuf>,
+}
+
+impl SetupConfig {
+   /// Sets the directory the download store is persisted in.
+   ///
+   /// The filename is fixed at `downloads.json` everywhere; this names the directory
+   /// holding it. Must be absolute, and on mobile inside the app sandbox — which only
+   /// `app.path()` can name, and the reason this is a hook rather than a setter.
+   ///
+   /// Unset, each platform keeps its default: the app data directory on desktop,
+   /// internal storage on Android, `Documents` on iOS.
+   ///
+   /// Changing it does not migrate an existing store; its records become invisible.
+   pub fn store_dir(&mut self, dir: impl Into<PathBuf>) -> &mut Self {
+      self.store_dir = Some(dir.into());
+      self
+   }
+}
+
 /// Plugin builder for configuring the download manager before initialization.
 ///
 /// # Examples
 ///
 /// ```no_run
+/// use tauri::Manager;
+///
 /// tauri::Builder::default()
 ///    .plugin(
 ///       tauri_plugin_download::Builder::new()
 ///          .user_agent("my-app/1.0")
+///          .on_setup(|app, config| {
+///             config.store_dir(app.path().app_data_dir()?.join("downloads"));
+///             Ok(())
+///          })
 ///          .build(),
 ///    );
 /// ```
-#[derive(Debug, Default)]
-pub struct Builder {
+pub struct Builder<R: Runtime> {
    user_agent: Option<String>,
+   on_setup: Option<OnSetupHook<R>>,
 }
 
-impl Builder {
+/// Hand-written rather than derived: a boxed closure is not [`Debug`], and deriving
+/// would additionally require `R: Debug`, which no runtime satisfies.
+impl<R: Runtime> std::fmt::Debug for Builder<R> {
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+      f.debug_struct("Builder")
+         .field("user_agent", &self.user_agent)
+         .field("on_setup", &self.on_setup.is_some())
+         .finish()
+   }
+}
+
+/// Hand-written for the same reason `Debug` is: `#[derive(Default)]` would require
+/// `R: Default`.
+impl<R: Runtime> Default for Builder<R> {
+   fn default() -> Self {
+      Self {
+         user_agent: None,
+         on_setup: None,
+      }
+   }
+}
+
+impl<R: Runtime> Builder<R> {
    /// Creates a new builder, leaving every platform's own defaults in place.
    pub fn new() -> Self {
       Self::default()
+   }
+
+   /// Registers a hook that runs during plugin setup, once the `app` instance exists.
+   ///
+   /// The only way to set a store directory: legitimate directories come from
+   /// `app.path()`, and the builder runs before `tauri::Builder::run` creates the app.
+   /// On mobile it is also the only way to name a writable sandbox directory.
+   ///
+   /// Returning `Err` aborts startup, as an invalid [`user_agent`](Self::user_agent) does.
+   pub fn on_setup(
+      mut self,
+      f: impl FnOnce(
+         &AppHandle<R>,
+         &mut SetupConfig,
+      ) -> std::result::Result<(), Box<dyn std::error::Error>>
+      + Send
+      + 'static,
+   ) -> Self {
+      self.on_setup = Some(Box::new(f));
+      self
    }
 
    /// Sets the `User-Agent` header sent with every download request.
@@ -91,8 +178,9 @@ impl Builder {
    }
 
    /// Builds the Tauri plugin with the configured settings.
-   pub fn build<R: Runtime>(self) -> TauriPlugin<R> {
+   pub fn build(self) -> TauriPlugin<R> {
       let user_agent = self.user_agent;
+      let on_setup = self.on_setup;
 
       plugin::Builder::new("download")
          .invoke_handler(tauri::generate_handler![
@@ -106,18 +194,33 @@ impl Builder {
             commands::is_native,
          ])
          .setup(move |app, _api| {
+            // Runs first so the settings it resolves are validated below alongside the
+            // ones set on the builder, rather than reaching a platform unchecked.
+            let mut config = SetupConfig::default();
+            if let Some(on_setup) = on_setup {
+               on_setup(app, &mut config)?;
+            }
+
             // Validated before either platform branch so an invalid value fails the
             // same way everywhere, rather than only where the transport rejects it.
             if let Some(ref user_agent) = user_agent {
                download_manager::validate_user_agent(user_agent)?;
             }
 
+            if let Some(ref store_dir) = config.store_dir {
+               download_manager::validate_store_dir(store_dir)?;
+            }
+
             #[cfg(desktop)]
             {
-               // Resolve the app data directory for store persistence.
-               let data_dir = app.path().app_data_dir().unwrap_or_else(|e| {
-                  warn!("Failed to resolve app data dir, falling back to '.': {}", e);
-                  std::path::PathBuf::from(".")
+               // A configured store directory is used as given. Only the default is
+               // resolved — and only it falls back, since a caller who named a
+               // directory should not silently get a different one.
+               let data_dir = config.store_dir.unwrap_or_else(|| {
+                  app.path().app_data_dir().unwrap_or_else(|e| {
+                     warn!("Failed to resolve app data dir, falling back to '.': {}", e);
+                     std::path::PathBuf::from(".")
+                  })
                });
 
                // Wire Tauri event emission as the on_changed callback.
@@ -158,7 +261,7 @@ impl Builder {
 ///
 /// Use [`Builder`] to configure it.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-   Builder::new().build()
+   Builder::<R>::new().build()
 }
 
 #[cfg(test)]
@@ -170,7 +273,7 @@ mod tests {
       // Not tautological: the field is read once, in `build`, and a setter that
       // dropped its argument would leave every download on the platform default with
       // nothing failing.
-      let builder = Builder::new().user_agent("my-app/1.0");
+      let builder = Builder::<tauri::test::MockRuntime>::new().user_agent("my-app/1.0");
 
       assert_eq!(builder.user_agent, Some("my-app/1.0".to_string()));
    }
@@ -195,5 +298,111 @@ mod tests {
          .build(tauri::test::mock_context(tauri::test::noop_assets()));
 
       assert!(app.is_ok());
+   }
+
+   #[test]
+   fn test_store_dir_setter_stores_the_value() {
+      // Same reasoning as the user agent setter above: the field is read once, in
+      // `build`, so a setter that dropped its argument would silently leave the store
+      // at the platform default.
+      let mut config = SetupConfig::default();
+
+      config.store_dir("/var/lib/myapp");
+
+      assert_eq!(config.store_dir, Some(PathBuf::from("/var/lib/myapp")));
+   }
+
+   #[test]
+   fn test_the_setup_hook_runs_during_plugin_initialization() {
+      // The hook exists to be run with an app handle that only exists at setup time.
+      // Without this, `on_setup` could store a closure that is never called and every
+      // other test here would still pass.
+      let ran = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+      let flag = ran.clone();
+
+      let app = tauri::test::mock_builder()
+         .plugin(
+            Builder::new()
+               .on_setup(move |_app, _config| {
+                  flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                  Ok(())
+               })
+               .build(),
+         )
+         .build(tauri::test::mock_context(tauri::test::noop_assets()));
+
+      assert!(app.is_ok());
+      assert!(ran.load(std::sync::atomic::Ordering::SeqCst));
+   }
+
+   #[test]
+   fn test_a_relative_store_dir_fails_plugin_initialization() {
+      // The mirror of the invalid user agent case. `validate_store_dir` runs ahead of
+      // the desktop/mobile split, so this resolves on any host without a mobile target.
+      let app = tauri::test::mock_builder()
+         .plugin(
+            Builder::new()
+               .on_setup(|_app, config| {
+                  config.store_dir("downloads");
+                  Ok(())
+               })
+               .build(),
+         )
+         .build(tauri::test::mock_context(tauri::test::noop_assets()));
+
+      assert!(matches!(app, Err(tauri::Error::PluginInitialization(_, _))));
+   }
+
+   #[test]
+   fn test_an_error_from_the_setup_hook_fails_plugin_initialization() {
+      // The documented contract: a caller whose `app.path()` lookup fails aborts
+      // startup rather than silently falling back to a directory they did not choose.
+      let app = tauri::test::mock_builder()
+         .plugin(
+            Builder::new()
+               .on_setup(|_app, _config| Err("no directory for you".into()))
+               .build(),
+         )
+         .build(tauri::test::mock_context(tauri::test::noop_assets()));
+
+      assert!(matches!(app, Err(tauri::Error::PluginInitialization(_, _))));
+   }
+
+   #[cfg(desktop)]
+   #[test]
+   fn test_the_store_is_persisted_in_the_configured_directory() {
+      use download_manager::DownloadItem;
+
+      // The feature itself, end to end through the plugin: creating a download has to
+      // write `downloads.json` into the configured directory. Asserting on the setter
+      // alone would pass even if `build` ignored the value.
+      let dir = tempfile::tempdir().unwrap();
+      let store_dir = dir.path().join("configured");
+      let expected = store_dir.join("downloads.json");
+
+      let configured = store_dir.clone();
+      let app = tauri::test::mock_builder()
+         .plugin(
+            Builder::new()
+               .on_setup(move |_app, config| {
+                  config.store_dir(configured.clone());
+                  Ok(())
+               })
+               .build(),
+         )
+         .build(tauri::test::mock_context(tauri::test::noop_assets()))
+         .unwrap();
+
+      let download: DownloadItem = app
+         .download()
+         .create(
+            dir.path().join("file.mp4").to_str().unwrap(),
+            "https://example.com/file.mp4",
+         )
+         .unwrap()
+         .download;
+
+      assert_eq!(download.status, download_manager::DownloadStatus::Idle);
+      assert!(expected.exists(), "store not written to {:?}", expected);
    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,8 +239,20 @@ impl<R: Runtime> Builder<R> {
 
             #[cfg(mobile)]
             {
+               // The bridge to native is JSON, so the directory has to be UTF-8. A path
+               // that is not fails here rather than being dropped, which would leave the
+               // store at the platform default with nothing having failed.
+               let store_dir = match config.store_dir {
+                  Some(dir) => Some(
+                     dir.to_str()
+                        .ok_or_else(|| format!("Store directory is not valid UTF-8: {:?}", dir))?
+                        .to_string(),
+                  ),
+                  None => None,
+               };
+
                // Mobile download management is handled natively by the platform plugin.
-               let download = mobile::init(app, _api, user_agent)?;
+               let download = mobile::init(app, _api, user_agent, store_dir)?;
                app.manage(download);
             }
 

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -14,6 +14,7 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
    _app: &AppHandle<R>,
    _api: PluginApi<R, C>,
    user_agent: Option<String>,
+   store_dir: Option<String>,
 ) -> crate::Result<Download<R>> {
    #[cfg(target_os = "android")]
    let handle = _api.register_android_plugin(PLUGIN_IDENTIFIER, "DownloadPlugin")?;
@@ -22,19 +23,20 @@ pub fn init<R: Runtime, C: DeserializeOwned>(
 
    let download = Download(handle);
 
-   // Pushed because the plugin config Tauri forwards to `load()` comes from
-   // `tauri.conf.json`, so a builder value cannot ride it. Registration blocks and
-   // runs inside `Builder::build`, before `App::run` creates any webview.
+   // Pushed as a command because the plugin config Tauri forwards to `load()` comes
+   // from `tauri.conf.json`, which a builder value cannot ride. What keeps `configure`
+   // unreachable from JS is the ACL, not its absence from `generate_handler!` — that
+   // absence is what routes it to native. The invariant is that it never enters COMMANDS.
    //
-   // What keeps `configure` unreachable from JS is the ACL, not its absence from
-   // `generate_handler!` — absence is what routes to native, as `registerListener`
-   // does. The invariant is that `configure` never enters COMMANDS.
+   // Invoked unconditionally, even with nothing to set: both natives build their
+   // download manager on first touch, and this is what touches it first — before
+   // `load(webView)`, which Tauri defers until the webview exists. Skipping it would
+   // hand that first touch to another caller, and on iOS delay the background
+   // `URLSession` that restores in-flight downloads.
    //
-   // A transport failure aborts launch, deliberately: with `release_max_level_off`,
-   // "log and continue" would ship the wrong agent silently.
-   if let Some(user_agent) = user_agent {
-      download.configure(&user_agent)?;
-   }
+   // A transport failure aborts launch deliberately: under `release_max_level_off`,
+   // "log and continue" would ship the wrong agent or the wrong store silently.
+   download.configure(user_agent, store_dir)?;
 
    Ok(download)
 }
@@ -48,12 +50,17 @@ impl<R: Runtime> Download<R> {
    ///
    /// Deliberately not public: it is only correct to call once, before any download
    /// exists. A later change would reach Android only for work enqueued after it and
-   /// iOS only for newly created tasks, which is not a contract worth offering.
+   /// iOS only for newly created tasks, which is not a contract worth offering. The
+   /// store directory is stricter still — both natives read it when they construct
+   /// their store, so a later call could not move an already-open file.
    ///
    /// # Arguments
-   /// - `user_agent` - The user agent sent with every download request.
+   /// - `user_agent` - The user agent sent with every download request, or `None` to
+   ///   leave the platform's own default.
+   /// - `store_dir` - The directory holding `downloads.json`, or `None` to leave the
+   ///   platform's own default.
    ///
-   fn configure(&self, user_agent: &str) -> crate::Result<()> {
+   fn configure(&self, user_agent: Option<String>, store_dir: Option<String>) -> crate::Result<()> {
       // A bare `invoke.resolve()` sends the literal `null` on both platforms, which
       // is what `()` decodes from. Anything else here would fail to deserialize.
       self
@@ -61,7 +68,8 @@ impl<R: Runtime> Download<R> {
          .run_mobile_plugin(
             "configure",
             ConfigArgs {
-               user_agent: user_agent.to_string(),
+               user_agent,
+               store_dir,
             },
          )
          .map_err(Into::into)

--- a/src/models.rs
+++ b/src/models.rs
@@ -38,12 +38,16 @@ mod mobile_types {
 
    /// Settings pushed to the native plugin once at startup.
    ///
-   /// Named for the payload rather than the setting so a second builder option is a
-   /// new field here, not a second command mirrored across Kotlin and Swift.
+   /// Named for the payload rather than the setting, so a second builder option is a
+   /// new field here rather than a second command mirrored across Kotlin and Swift.
+   ///
+   /// Every field is optional: the command is invoked unconditionally, so absent means
+   /// "keep the platform default", not a malformed call.
    #[derive(Serialize)]
    #[serde(rename_all = "camelCase")]
    pub struct ConfigArgs {
-      pub user_agent: String,
+      pub user_agent: Option<String>,
+      pub store_dir: Option<String>,
    }
 
    #[derive(Serialize)]


### PR DESCRIPTION
Closes #27.

## What this adds

A host app can choose the directory holding `downloads.json`. Unset, every platform keeps its current default.

```rust
tauri_plugin_download::Builder::new()
   .user_agent("my-app/1.0")
   .on_setup(|app, config| {
      config.store_dir(app.path().app_data_dir()?.join("downloads"));
      Ok(())
   })
   .build()
```

It goes through `on_setup` rather than a plain setter because the builder runs before `tauri::Builder::run` creates the app, so a call site has no `app.path()` — and on mobile that is the only way to name a writable sandbox directory. Same shape as `tauri-plugin-sqlite`. `Builder` becomes `Builder<R: Runtime>` as a result.

**No migration.** Pointing `store_dir` somewhere new leaves existing records where they are. Deliberate, and documented.

## Testing

Rust, Swift and Android suites pass, plus `cargo check --target aarch64-apple-ios` and an `xcodebuild` of the iOS plugin bridge. clippy, rustfmt and markdownlint clean.

## Draft because

- **No on-device run.** The ordering invariant — `configure` builds the native manager before anything else touches it — is verified from Tauri's source, not observed.
- **A known narrow race.** If an app changes `store_dir` between releases while work enqueued under the old directory is still queued, the Android worker can pin the store first and `configure`'s directory is discarded with only a `Log.w`.
- **CI compiles neither mobile plugin bridge.** Pre-existing, but this branch puts ordering-sensitive logic in both.